### PR TITLE
Add keyboard shortcuts

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -32,6 +32,7 @@
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
         "react-hook-form": "^7.59.0",
+        "react-hotkeys-hook": "^5.1.0",
         "tailwind-merge": "^3.3.1",
         "zod": "^3.25.71"
     },

--- a/web/pnpm-lock.yaml
+++ b/web/pnpm-lock.yaml
@@ -68,6 +68,9 @@ importers:
       react-hook-form:
         specifier: ^7.59.0
         version: 7.59.0(react@19.1.0)
+      react-hotkeys-hook:
+        specifier: ^5.1.0
+        version: 5.1.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       tailwind-merge:
         specifier: ^3.3.1
         version: 3.3.1
@@ -2373,6 +2376,12 @@ packages:
     engines: {node: '>=18.0.0'}
     peerDependencies:
       react: ^16.8.0 || ^17 || ^18 || ^19
+
+  react-hotkeys-hook@5.1.0:
+    resolution: {integrity: sha512-GCNGXjBzV9buOS3REoQFmSmE4WTvBhYQ0YrAeeMZI83bhXg3dRWsLHXDutcVDdEjwJqJCxk5iewWYX5LtFUd7g==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
 
   react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
@@ -5017,6 +5026,11 @@ snapshots:
   react-hook-form@7.59.0(react@19.1.0):
     dependencies:
       react: 19.1.0
+
+  react-hotkeys-hook@5.1.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
+    dependencies:
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
 
   react-is@16.13.1: {}
 

--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -42,6 +42,7 @@
     --color-popover: var(--popover);
     --color-card-foreground: var(--card-foreground);
     --color-card: var(--card);
+    --color-kbd: var(--kbd);
     --radius-sm: calc(var(--radius) - 4px);
     --radius-md: calc(var(--radius) - 2px);
     --radius-lg: var(--radius);
@@ -86,6 +87,7 @@
     --heatmap-2: oklch(0.81 0.1 143);
     --heatmap-3: oklch(0.73 0.15 143);
     --heatmap-4: oklch(0.65 0.2 143);
+    --kbd: oklch(0.97 0.005 240);
 }
 
 .dark {
@@ -125,6 +127,7 @@
     --heatmap-2: oklch(0.469 0.1 143);
     --heatmap-3: oklch(0.569 0.15 143);
     --heatmap-4: oklch(0.65 0.2 143);
+    --kbd: oklch(0.25 0.01 240);
 }
 
 @layer base {

--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -87,7 +87,7 @@
     --heatmap-2: oklch(0.81 0.1 143);
     --heatmap-3: oklch(0.73 0.15 143);
     --heatmap-4: oklch(0.65 0.2 143);
-    --kbd: oklch(0.97 0.005 240);
+    --kbd: oklch(0.97 0 0);
 }
 
 .dark {
@@ -127,7 +127,7 @@
     --heatmap-2: oklch(0.469 0.1 143);
     --heatmap-3: oklch(0.569 0.15 143);
     --heatmap-4: oklch(0.65 0.2 143);
-    --kbd: oklch(0.25 0.01 240);
+    --kbd: oklch(0.25 0 0);
 }
 
 @layer base {

--- a/web/src/app/providers.tsx
+++ b/web/src/app/providers.tsx
@@ -3,6 +3,7 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { ThemeProvider } from 'next-themes';
 
+import { ShortcutProvider } from '@/components/ShortcutProvider';
 import { SidebarProvider } from '@/components/ui/sidebar';
 import '@/lib/api-client';
 
@@ -15,7 +16,9 @@ export function AppProviders({
     return (
         <QueryClientProvider client={queryClient}>
             <ThemeProvider {...props}>
-                <SidebarProvider>{children}</SidebarProvider>
+                <SidebarProvider>
+                    <ShortcutProvider>{children}</ShortcutProvider>
+                </SidebarProvider>
             </ThemeProvider>
         </QueryClientProvider>
     );

--- a/web/src/components/ActivityHeatmap.tsx
+++ b/web/src/components/ActivityHeatmap.tsx
@@ -142,11 +142,6 @@ export function ActivityHeatmap({ className, heatmapData }: Props) {
                                                               )
                                                             : 'bg-heatmap-0'
                                                     }`}
-                                                    title={
-                                                        day
-                                                            ? `${formatDateForDisplay(day.date)}: ${day.numberOfReviews} reviews`
-                                                            : ''
-                                                    }
                                                 />
                                             </TooltipTrigger>
                                             <TooltipContent>

--- a/web/src/components/Kbd.tsx
+++ b/web/src/components/Kbd.tsx
@@ -1,0 +1,25 @@
+import { getShortcut } from '@/lib/shortcuts';
+
+interface KbdProps {
+    action: string;
+    scope: string;
+    className?: string;
+}
+
+export default function Kbd({ action, scope, className = '' }: KbdProps) {
+    const shortcutKey = getShortcut(action, scope).key;
+
+    if (!shortcutKey) return null;
+
+    function formatKey(key: string) {
+        return key.replace('ctrl+', '⌃').replace('escape', 'Esc');
+    }
+
+    return (
+        <kbd
+            className={`bg-kbd text-primary inline-flex items-center justify-center rounded p-1 font-mono font-medium ${className}`}
+        >
+            {formatKey(shortcutKey)}
+        </kbd>
+    );
+}

--- a/web/src/components/ShortcutProvider.tsx
+++ b/web/src/components/ShortcutProvider.tsx
@@ -1,0 +1,54 @@
+import {
+    createContext,
+    useContext,
+    useCallback,
+    useRef,
+    ReactNode,
+} from 'react';
+
+interface ShortcutContextType {
+    registerAction: (action: string, handler: () => void) => void;
+    unregisterAction: (action: string) => void;
+    executeAction: (action: string) => void;
+}
+
+const ShortcutContext = createContext<ShortcutContextType | null>(null);
+
+export function ShortcutProvider({ children }: { children: ReactNode }) {
+    const actionsRef = useRef(new Map<string, () => void>());
+
+    const registerAction = useCallback(
+        (action: string, handler: () => void) => {
+            actionsRef.current.set(action, handler);
+        },
+        []
+    );
+
+    const unregisterAction = useCallback((action: string) => {
+        actionsRef.current.delete(action);
+    }, []);
+
+    const executeAction = useCallback((action: string) => {
+        const handler = actionsRef.current.get(action);
+        if (handler) {
+            handler();
+        }
+    }, []);
+
+    return (
+        <ShortcutContext.Provider
+            value={{ registerAction, unregisterAction, executeAction }}
+        >
+            {children}
+        </ShortcutContext.Provider>
+    );
+}
+
+export function useShortcutActions() {
+    const context = useContext(ShortcutContext);
+    if (!context)
+        throw new Error(
+            'useShortcutActions must be used within ShortcutProvider'
+        );
+    return context;
+}

--- a/web/src/config/shortcuts.ts
+++ b/web/src/config/shortcuts.ts
@@ -1,0 +1,21 @@
+export interface ShortcutConfig {
+    key: string;
+    action: string;
+    description: string;
+    scope: 'decks' | 'profile' | 'review';
+}
+
+export const SHORTCUT_CONFIG: ShortcutConfig[] = [
+    {
+        key: 'j',
+        action: 'card-forgot',
+        description: 'Mark card as forgotten',
+        scope: 'review',
+    },
+    {
+        key: 'l',
+        action: 'card-ok',
+        description: 'Mark card as remembered',
+        scope: 'review',
+    },
+];

--- a/web/src/hooks/use-shortcuts.ts
+++ b/web/src/hooks/use-shortcuts.ts
@@ -1,0 +1,36 @@
+import { useHotkeys } from 'react-hotkeys-hook';
+
+import { useShortcutActions } from '@/components/ShortcutProvider';
+import { getShortcutsForScope } from '@/lib/shortcuts';
+
+export const usePageShortcuts = (scope: string, enabled = true) => {
+    const { executeAction } = useShortcutActions();
+    const shortcuts = getShortcutsForScope(scope);
+
+    const keyToAction = shortcuts.reduce(
+        (acc, { key, action }) => {
+            acc[key] = action;
+            return acc;
+        },
+        {} as Record<string, string>
+    );
+
+    const allKeys = shortcuts.map((s) => s.key);
+
+    useHotkeys(
+        allKeys,
+        (event) => {
+            const action = keyToAction[event.key];
+            if (action) {
+                executeAction(action);
+            }
+        },
+        {
+            enabled,
+            preventDefault: true,
+            enableOnFormTags: false,
+        }
+    );
+
+    return shortcuts;
+};

--- a/web/src/lib/shortcuts.ts
+++ b/web/src/lib/shortcuts.ts
@@ -1,0 +1,28 @@
+import { SHORTCUT_CONFIG } from '@/config/shortcuts';
+
+export function createActions<T extends Record<string, () => void>>(
+    actions: T & Record<string, () => void>
+): T {
+    const allowedActions = new Set(SHORTCUT_CONFIG.map((c) => c.action));
+    const providedActions = new Set(Object.keys(actions));
+
+    const diff = providedActions.difference(allowedActions);
+    if (diff.size > 0) {
+        throw new Error(`Unknown action(s): ${Array.from(diff)}`);
+    }
+    return actions;
+}
+
+export function getShortcutsForScope(scope: string) {
+    return SHORTCUT_CONFIG.filter((shortcut) => shortcut.scope === scope);
+}
+
+export function getShortcut(action: string, scope: string) {
+    const shortcut = SHORTCUT_CONFIG.find(
+        (item) => item.action === action && item.scope === scope
+    );
+    if (shortcut === undefined) {
+        throw new Error(`Unknown action ${action} or scope ${scope}`);
+    }
+    return shortcut;
+}


### PR DESCRIPTION
To use:
1. Add your shortcut config to `web/src/config/shortcuts.ts`
2. Call the `usePageShortcuts()` hook in page/component
3. Register actions and the corresponding function in `useEffect`
4. Add `<Kbd />` element next to button/actionable item

Still TODO:
- Adjust shortcut keys
- Adjust Kbd element colors (+add border?)
- The `useHotkeys` hook can take a scope, maybe set that to be our scopes from the config
- Add more shortcuts (global/site-wide shortcuts?)
- Fetch the user shortcut configuration from the backend (maybe as part of `/me`?) and use those as the config, but still use the default values from `web/src/config/shortcuts.ts` as fallback


https://github.com/user-attachments/assets/e3fc0417-81b9-429f-aed0-fbcc2e273d25


https://github.com/user-attachments/assets/183935b4-6f94-468c-9768-b11db7e5538a

