### PR TITLE
Enhance decks and cards

### DIFF
--- a/web/src/app/decks/page.tsx
+++ b/web/src/app/decks/page.tsx
@@ -1,80 +1,53 @@
 'use client';
 
+import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { Plus } from 'lucide-react';
-import { useEffect, useState } from 'react';
 
 import CardCreationDialog from '@/components/CardCreationDialog';
 import DeckCreationDialog from '@/components/DeckCreationDialog';
 import { Button } from '@/components/ui/button';
 import { Card, CardHeader, CardContent } from '@/components/ui/card';
-import { getDecksDecksGet, DeckOut, getCardsCardsGet, CardOut } from '@/gen';
+import { getDecksDecksGet, getCardsCardsGet } from '@/gen';
 
 export default function Decks() {
-    const [decksState, setDecksState] = useState({
-        data: [] as DeckOut[],
-        loading: true,
-        error: null as string | null,
+    const queryClient = useQueryClient();
+
+    const {
+        data: decks,
+        isLoading: isDecksLoading,
+        isError: isDecksError,
+        error: decksError,
+    } = useQuery({
+        queryKey: ['decks'],
+        queryFn: () => getDecksDecksGet(),
     });
 
-    const [cardsState, setCardsState] = useState({
-        data: [] as CardOut[],
-        loading: true,
-        error: null as string | null,
+    const {
+        data: cards,
+        isLoading: isCardsLoading,
+        isError: isCardsError,
+        error: cardsError,
+    } = useQuery({
+        queryKey: ['cards'],
+        queryFn: () => getCardsCardsGet(),
     });
-
-    useEffect(() => {
-        fetchDecks();
-        fetchCards();
-    }, []);
-
-    async function fetchDecks() {
-        try {
-            setDecksState((prev) => ({ ...prev, error: null }));
-            const response = await getDecksDecksGet();
-            setDecksState((prev) => ({
-                ...prev,
-                data: response.data || [],
-                loading: false,
-            }));
-        } catch {
-            setDecksState({
-                data: [],
-                loading: false,
-                error: 'There was an error while fetching decks',
-            });
-        }
-    }
-
-    async function fetchCards() {
-        try {
-            setCardsState((prev) => ({ ...prev, error: null }));
-            const response = await getCardsCardsGet();
-            setCardsState((prev) => ({
-                ...prev,
-                data: response.data || [],
-                loading: false,
-            }));
-        } catch {
-            setCardsState({
-                data: [],
-                loading: false,
-                error: 'There was an error while fetching cards',
-            });
-        }
-    }
 
     return (
         <div className="container mx-auto space-y-8 px-6 py-6">
             <div>
                 <h1 className="mb-6 text-2xl font-medium">Decks</h1>
 
-                {decksState.loading && <p>Loading decks...</p>}
-                {decksState.error && <p>{decksState.error}</p>}
-                {!decksState.loading && !decksState.error && (
+                {isDecksLoading && <p>Loading decks...</p>}
+                {isDecksError && <p>{decksError.message}</p>}
+                {!isDecksLoading && !isDecksError && (
                     <div className="grid grid-cols-2 gap-4 md:grid-cols-[repeat(auto-fill,minmax(8rem,1fr))]">
                         <Card className="flex aspect-[3/4] flex-col items-center justify-center border-2 border-dashed shadow-none">
                             <DeckCreationDialog
-                                onSuccess={fetchDecks}
+                                onSuccess={() =>
+                                    queryClient.invalidateQueries({
+                                        queryKey: ['decks'],
+                                    })
+                                }
                                 trigger={
                                     <Button
                                         variant="outline"
@@ -85,8 +58,9 @@ export default function Decks() {
                                 }
                             ></DeckCreationDialog>
                         </Card>
-                        {decksState.data.length > 0 &&
-                            decksState.data.map((deck) => (
+                        {decks?.data &&
+                            decks.data.length > 0 &&
+                            decks.data.map((deck) => (
                                 <Card
                                     key={deck.id}
                                     className="flex aspect-[3/4] flex-col gap-2 p-4"
@@ -110,14 +84,18 @@ export default function Decks() {
             <div>
                 <h1 className="mb-6 text-2xl font-medium">Cards</h1>
 
-                {cardsState.loading && <p>Loading cards...</p>}
-                {cardsState.error && <p>{cardsState.error}</p>}
-                {!cardsState.loading && !cardsState.error && (
+                {isCardsLoading && <p>Loading cards...</p>}
+                {isCardsError && <p>{cardsError.message}</p>}
+                {!isCardsLoading && !isCardsError && (
                     <div className="grid grid-cols-2 gap-4 md:grid-cols-[repeat(auto-fill,minmax(8rem,1fr))]">
                         <Card className="flex aspect-[3/4] flex-col items-center justify-center border-2 border-dashed shadow-none">
                             <CardCreationDialog
-                                decks={decksState.data}
-                                onSuccess={fetchCards}
+                                decks={decks?.data || []}
+                                onSuccess={() =>
+                                    queryClient.invalidateQueries({
+                                        queryKey: ['cards'],
+                                    })
+                                }
                                 trigger={
                                     <Button
                                         variant="outline"
@@ -128,15 +106,16 @@ export default function Decks() {
                                 }
                             ></CardCreationDialog>
                         </Card>
-                        {cardsState.data.length > 0 &&
-                            cardsState.data.map((card) => (
+                        {cards?.data &&
+                            cards.data.length > 0 &&
+                            cards.data.map((card) => (
                                 <Card
                                     key={card.id}
                                     className="flex aspect-[3/4] flex-col gap-1 p-4"
                                 >
                                     <CardHeader className="p-0">
                                         <p className="text-xs text-neutral-600">
-                                            {decksState.data.find(
+                                            {decks?.data?.find(
                                                 (deck) =>
                                                     deck.id === card.deck_id
                                             )?.name || '-'}

--- a/web/src/app/decks/page.tsx
+++ b/web/src/app/decks/page.tsx
@@ -56,7 +56,7 @@ export default function Decks() {
                                         <Plus /> New
                                     </Button>
                                 }
-                            ></DeckCreationDialog>
+                            />
                         </Card>
                         {decks?.data &&
                             decks.data.length > 0 &&
@@ -90,7 +90,6 @@ export default function Decks() {
                     <div className="grid grid-cols-2 gap-4 md:grid-cols-[repeat(auto-fill,minmax(8rem,1fr))]">
                         <Card className="flex aspect-[3/4] flex-col items-center justify-center border-2 border-dashed shadow-none">
                             <CardCreationDialog
-                                decks={decks?.data || []}
                                 onSuccess={() =>
                                     queryClient.invalidateQueries({
                                         queryKey: ['cards'],
@@ -104,7 +103,7 @@ export default function Decks() {
                                         <Plus /> New
                                     </Button>
                                 }
-                            ></CardCreationDialog>
+                            />
                         </Card>
                         {cards?.data &&
                             cards.data.length > 0 &&

--- a/web/src/components/AppSidebar.tsx
+++ b/web/src/components/AppSidebar.tsx
@@ -40,7 +40,8 @@ const pages = [
 export function AppSidebar() {
     const pathname = usePathname();
     const queryClient = useQueryClient();
-    const [creationDropdownOpen, setCreationDropdownOpen] = useState(false);
+    const [cardDialogOpen, setCardDialogOpen] = useState(false);
+    const [deckDialogOpen, setDeckDialogOpen] = useState(false);
 
     const {
         data: user,
@@ -56,48 +57,44 @@ export function AppSidebar() {
             <SidebarHeader>
                 <SidebarMenu>
                     <SidebarMenuItem>
-                        <DropdownMenu
-                            open={creationDropdownOpen}
-                            onOpenChange={setCreationDropdownOpen}
-                        >
+                        <DropdownMenu>
                             <DropdownMenuTrigger asChild>
                                 <Button className="w-full">Create</Button>
                             </DropdownMenuTrigger>
                             <DropdownMenuContent className="w-[var(--radix-dropdown-menu-trigger-width)]">
-                                <CardCreationDialog
-                                    onSuccess={() => {
-                                        queryClient.invalidateQueries({
-                                            queryKey: ['cards'],
-                                        });
-                                        setCreationDropdownOpen(false);
-                                    }}
-                                    onOpenChange={setCreationDropdownOpen}
-                                    trigger={
-                                        <DropdownMenuItem
-                                            onSelect={(e) => e.preventDefault()}
-                                        >
-                                            Create card
-                                        </DropdownMenuItem>
-                                    }
-                                />
-                                <DeckCreationDialog
-                                    onSuccess={() => {
-                                        queryClient.invalidateQueries({
-                                            queryKey: ['decks'],
-                                        });
-                                        setCreationDropdownOpen(false);
-                                    }}
-                                    onOpenChange={setCreationDropdownOpen}
-                                    trigger={
-                                        <DropdownMenuItem
-                                            onSelect={(e) => e.preventDefault()}
-                                        >
-                                            Create deck
-                                        </DropdownMenuItem>
-                                    }
-                                />
+                                <DropdownMenuItem
+                                    onClick={() => setCardDialogOpen(true)}
+                                >
+                                    Create card
+                                </DropdownMenuItem>
+                                <DropdownMenuItem
+                                    onClick={() => setDeckDialogOpen(true)}
+                                >
+                                    Create deck
+                                </DropdownMenuItem>
                             </DropdownMenuContent>
                         </DropdownMenu>
+
+                        <CardCreationDialog
+                            open={cardDialogOpen}
+                            onOpenChange={setCardDialogOpen}
+                            onSuccess={() => {
+                                queryClient.invalidateQueries({
+                                    queryKey: ['cards'],
+                                });
+                                setCardDialogOpen(false);
+                            }}
+                        />
+                        <DeckCreationDialog
+                            open={deckDialogOpen}
+                            onOpenChange={setDeckDialogOpen}
+                            onSuccess={() => {
+                                queryClient.invalidateQueries({
+                                    queryKey: ['decks'],
+                                });
+                                setDeckDialogOpen(false);
+                            }}
+                        />
                     </SidebarMenuItem>
                 </SidebarMenu>
             </SidebarHeader>

--- a/web/src/components/AppSidebar.tsx
+++ b/web/src/components/AppSidebar.tsx
@@ -1,10 +1,13 @@
 'use client';
-import { useQuery } from '@tanstack/react-query';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { UserPlus, UserRoundX, User, LogIn, LogOut } from 'lucide-react';
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
+import { useState } from 'react';
 import { toast } from 'sonner';
 
+import CardCreationDialog from '@/components/CardCreationDialog';
+import DeckCreationDialog from '@/components/DeckCreationDialog';
 import ThemeChanger from '@/components/ThemeChanger';
 import { Avatar, AvatarFallback } from '@/components/ui/avatar';
 import { Button } from '@/components/ui/button';
@@ -36,6 +39,8 @@ const pages = [
 
 export function AppSidebar() {
     const pathname = usePathname();
+    const queryClient = useQueryClient();
+    const [creationDropdownOpen, setCreationDropdownOpen] = useState(false);
 
     const {
         data: user,
@@ -51,9 +56,48 @@ export function AppSidebar() {
             <SidebarHeader>
                 <SidebarMenu>
                     <SidebarMenuItem>
-                        <Button disabled className="w-full">
-                            Create
-                        </Button>
+                        <DropdownMenu
+                            open={creationDropdownOpen}
+                            onOpenChange={setCreationDropdownOpen}
+                        >
+                            <DropdownMenuTrigger asChild>
+                                <Button className="w-full">Create</Button>
+                            </DropdownMenuTrigger>
+                            <DropdownMenuContent className="w-[var(--radix-dropdown-menu-trigger-width)]">
+                                <CardCreationDialog
+                                    onSuccess={() => {
+                                        queryClient.invalidateQueries({
+                                            queryKey: ['cards'],
+                                        });
+                                        setCreationDropdownOpen(false);
+                                    }}
+                                    onOpenChange={setCreationDropdownOpen}
+                                    trigger={
+                                        <DropdownMenuItem
+                                            onSelect={(e) => e.preventDefault()}
+                                        >
+                                            Create card
+                                        </DropdownMenuItem>
+                                    }
+                                />
+                                <DeckCreationDialog
+                                    onSuccess={() => {
+                                        queryClient.invalidateQueries({
+                                            queryKey: ['decks'],
+                                        });
+                                        setCreationDropdownOpen(false);
+                                    }}
+                                    onOpenChange={setCreationDropdownOpen}
+                                    trigger={
+                                        <DropdownMenuItem
+                                            onSelect={(e) => e.preventDefault()}
+                                        >
+                                            Create deck
+                                        </DropdownMenuItem>
+                                    }
+                                />
+                            </DropdownMenuContent>
+                        </DropdownMenu>
                     </SidebarMenuItem>
                 </SidebarMenu>
             </SidebarHeader>

--- a/web/src/components/CardCreationDialog.tsx
+++ b/web/src/components/CardCreationDialog.tsx
@@ -1,4 +1,5 @@
 import { zodResolver } from '@hookform/resolvers/zod';
+import { useQuery } from '@tanstack/react-query';
 import { useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { z } from 'zod';
@@ -31,22 +32,26 @@ import {
     SelectValue,
 } from '@/components/ui/select';
 import { Textarea } from '@/components/ui/textarea';
-import { createCardCardsPost, CardCreate, DeckOut } from '@/gen';
+import { createCardCardsPost, CardCreate, getDecksDecksGet } from '@/gen';
 
 interface CardCreationDialogProps {
-    decks: DeckOut[];
     trigger: React.ReactNode;
     onSuccess?: () => void;
     onError?: (error: string) => void;
+    onOpenChange?: (open: boolean) => void;
 }
 
 export default function CardCreationDialog({
-    decks,
     trigger,
     onSuccess,
     onError,
+    onOpenChange,
 }: CardCreationDialogProps) {
     const [isCardDialogOpen, setIsCardDialogOpen] = useState(false);
+    const { data: decks } = useQuery({
+        queryKey: ['decks'],
+        queryFn: () => getDecksDecksGet(),
+    });
 
     const cardFormSchema = z.object({
         content: z.string().min(1, 'Card must have contents'),
@@ -79,7 +84,13 @@ export default function CardCreationDialog({
         }
     }
     return (
-        <Dialog open={isCardDialogOpen} onOpenChange={setIsCardDialogOpen}>
+        <Dialog
+            open={isCardDialogOpen}
+            onOpenChange={(open) => {
+                setIsCardDialogOpen(open);
+                onOpenChange?.(open);
+            }}
+        >
             <DialogTrigger asChild>{trigger}</DialogTrigger>
             <DialogContent>
                 <DialogHeader>
@@ -112,7 +123,7 @@ export default function CardCreationDialog({
                                                         Deck
                                                     </SelectLabel>
                                                 </SelectGroup>
-                                                {decks.map((deck) => (
+                                                {decks?.data?.map((deck) => (
                                                     <SelectItem
                                                         value={deck.id}
                                                         key={deck.id}
@@ -137,6 +148,7 @@ export default function CardCreationDialog({
                                     </FormLabel>
                                     <FormControl>
                                         <Textarea
+                                            className="h-32"
                                             placeholder={`How are you?
 ---
 Ça va?`}

--- a/web/src/components/CardCreationDialog.tsx
+++ b/web/src/components/CardCreationDialog.tsx
@@ -35,19 +35,24 @@ import { Textarea } from '@/components/ui/textarea';
 import { createCardCardsPost, CardCreate, getDecksDecksGet } from '@/gen';
 
 interface CardCreationDialogProps {
-    trigger: React.ReactNode;
+    trigger?: React.ReactNode;
+    open?: boolean;
+    onOpenChange?: (open: boolean) => void;
     onSuccess?: () => void;
     onError?: (error: string) => void;
-    onOpenChange?: (open: boolean) => void;
 }
 
 export default function CardCreationDialog({
     trigger,
+    open,
+    onOpenChange,
     onSuccess,
     onError,
-    onOpenChange,
 }: CardCreationDialogProps) {
-    const [isCardDialogOpen, setIsCardDialogOpen] = useState(false);
+    const [internalOpen, setInternalOpen] = useState(false);
+
+    const isOpen = open ?? internalOpen;
+    const setIsOpen = onOpenChange ?? setInternalOpen;
     const { data: decks } = useQuery({
         queryKey: ['decks'],
         queryFn: () => getDecksDecksGet(),
@@ -75,7 +80,7 @@ export default function CardCreationDialog({
                 },
             });
             cardForm.reset();
-            setIsCardDialogOpen(false);
+            setIsOpen(false);
 
             onSuccess?.();
         } catch (err: unknown) {
@@ -84,14 +89,8 @@ export default function CardCreationDialog({
         }
     }
     return (
-        <Dialog
-            open={isCardDialogOpen}
-            onOpenChange={(open) => {
-                setIsCardDialogOpen(open);
-                onOpenChange?.(open);
-            }}
-        >
-            <DialogTrigger asChild>{trigger}</DialogTrigger>
+        <Dialog open={isOpen} onOpenChange={setIsOpen}>
+            {trigger && <DialogTrigger asChild>{trigger}</DialogTrigger>}
             <DialogContent>
                 <DialogHeader>
                     <DialogTitle>Create card</DialogTitle>

--- a/web/src/components/DeckCreationDialog.tsx
+++ b/web/src/components/DeckCreationDialog.tsx
@@ -22,19 +22,20 @@ import {
     FormMessage,
 } from '@/components/ui/form';
 import { Input } from '@/components/ui/input';
-import { Textarea } from '@/components/ui/textarea';
 import { createDeckDecksPost, DeckCreate } from '@/gen';
 
 interface DeckCreationDialogProps {
     trigger: React.ReactNode;
     onSuccess?: () => void;
     onError?: (error: string) => void;
+    onOpenChange?: (open: boolean) => void;
 }
 
 export default function DeckCreationDialog({
     trigger,
     onSuccess,
     onError,
+    onOpenChange,
 }: DeckCreationDialogProps) {
     const [isDeckDialogOpen, setIsDeckDialogOpen] = useState(false);
 
@@ -69,7 +70,13 @@ export default function DeckCreationDialog({
         }
     }
     return (
-        <Dialog open={isDeckDialogOpen} onOpenChange={setIsDeckDialogOpen}>
+        <Dialog
+            open={isDeckDialogOpen}
+            onOpenChange={(open) => {
+                setIsDeckDialogOpen(open);
+                onOpenChange?.(open);
+            }}
+        >
             <DialogTrigger asChild>{trigger}</DialogTrigger>
             <DialogContent>
                 <DialogHeader>
@@ -92,7 +99,7 @@ export default function DeckCreationDialog({
                                         <Input
                                             type="text"
                                             placeholder="Deck name"
-                                            className="w-32"
+                                            className="w-40"
                                             {...field}
                                         />
                                     </FormControl>
@@ -109,7 +116,8 @@ export default function DeckCreationDialog({
                                         Description
                                     </FormLabel>
                                     <FormControl>
-                                        <Textarea
+                                        <Input
+                                            type="text"
                                             placeholder="Description"
                                             {...field}
                                         />

--- a/web/src/components/DeckCreationDialog.tsx
+++ b/web/src/components/DeckCreationDialog.tsx
@@ -25,19 +25,24 @@ import { Input } from '@/components/ui/input';
 import { createDeckDecksPost, DeckCreate } from '@/gen';
 
 interface DeckCreationDialogProps {
-    trigger: React.ReactNode;
+    trigger?: React.ReactNode;
+    open?: boolean;
+    onOpenChange?: (open: boolean) => void;
     onSuccess?: () => void;
     onError?: (error: string) => void;
-    onOpenChange?: (open: boolean) => void;
 }
 
 export default function DeckCreationDialog({
     trigger,
+    open,
+    onOpenChange,
     onSuccess,
     onError,
-    onOpenChange,
 }: DeckCreationDialogProps) {
-    const [isDeckDialogOpen, setIsDeckDialogOpen] = useState(false);
+    const [internalOpen, setInternalOpen] = useState(false);
+
+    const isOpen = open ?? internalOpen;
+    const setIsOpen = onOpenChange ?? setInternalOpen;
 
     const deckFormSchema = z.object({
         name: z.string().min(1, 'Deck name required').max(50),
@@ -61,7 +66,7 @@ export default function DeckCreationDialog({
                 },
             });
             deckForm.reset();
-            setIsDeckDialogOpen(false);
+            setIsOpen(false);
 
             onSuccess?.();
         } catch (err: unknown) {
@@ -70,14 +75,8 @@ export default function DeckCreationDialog({
         }
     }
     return (
-        <Dialog
-            open={isDeckDialogOpen}
-            onOpenChange={(open) => {
-                setIsDeckDialogOpen(open);
-                onOpenChange?.(open);
-            }}
-        >
-            <DialogTrigger asChild>{trigger}</DialogTrigger>
+        <Dialog open={isOpen} onOpenChange={setIsOpen}>
+            {trigger && <DialogTrigger asChild>{trigger}</DialogTrigger>}
             <DialogContent>
                 <DialogHeader>
                     <DialogTitle>Create deck</DialogTitle>


### PR DESCRIPTION
- Switch to useQuery for decks and cards on /decks
- Implement card and deck creation trigger in sidebar
- Refactor Card- and DeckCreationDialogs to allows both uncontrolled and controlled use
  - Uncontrolled: use with `trigger` and the component handles its own state
  - Controlled: use with open and onOpenChange to handle state in the parent component

Demo below. So nice to work with useQuery, invalidating the query keys for cards/decks when creating a card/deck in the dialog instantly updates the state in /decks

https://github.com/user-attachments/assets/2c79b791-5119-4f8e-9f44-cef0da9e7797

