### PR TITLE
Move admin bootstrap to app startup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,6 @@ migrate:
 
 .PHONY: bootstrap
 bootstrap:
-	$(BACKEND_EXEC) alembic upgrade head
 	$(BACKEND_EXEC) python -m src.db.bootstrap
 
 

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,5 +1,5 @@
 # https://github.com/astral-sh/uv-docker-example/blob/main/Dockerfile
-FROM ghcr.io/astral-sh/uv:python3.12-bookworm-slim as base
+FROM ghcr.io/astral-sh/uv:python3.12-bookworm-slim AS base
 
 WORKDIR /app
 
@@ -22,12 +22,12 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 
 ENV PATH="/app/.venv/bin:$PATH"
 
-FROM base as development
+FROM base AS development
 
 EXPOSE 8000
 CMD ["fastapi", "dev", "--host", "0.0.0.0", "src/main.py"]
 
-FROM base as production
+FROM base AS production
 
 RUN apt-get update && \
     apt-get install -y curl postgresql-client && \

--- a/backend/src/db/bootstrap.py
+++ b/backend/src/db/bootstrap.py
@@ -3,19 +3,13 @@ from uuid import UUID
 from sqlalchemy.orm import Session
 
 from src.db import get_db
-from src.db.models import Category, User, UserRole
+from src.db.models import Category, UserRole
 from src.import_export import BaseImporter, store_imported_deck
 from src.import_export.custom import CustomImporter
+from src.util import add_user
 
 FRENCH_DECK_JSON_PATH = "data/french.json"
 CHINESE_DECK_JSON_PATH = "data/chinese.json"
-
-
-def add_user(email: str, password: str, role: UserRole, db_session: Session) -> User:
-    user = User(email=email, role=role)
-    user.set_password(password)
-    user = user.save(db_session)
-    return user
 
 
 def add_category(user_id: UUID, name: str, db_session: Session) -> Category:
@@ -26,7 +20,6 @@ def add_category(user_id: UUID, name: str, db_session: Session) -> Category:
 
 def bootstrap():
     with next(get_db()) as db_session:
-        add_user("admin@domain.com", "password", UserRole.ADMIN, db_session)
         user = add_user("user@domain.com", "password", UserRole.USER, db_session)
 
         language_category = add_category(user.id, "Languages", db_session)

--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -1,3 +1,4 @@
+from contextlib import asynccontextmanager
 from os import getenv
 
 from dotenv import load_dotenv
@@ -18,8 +19,11 @@ from src.api import (
     reviews,
     statistics,
 )
+from src.db import get_db
+from src.db.models import UserRole
 from src.exceptions import RefreshTokenAuthenticationError
 from src.log import set_up_logger
+from src.util import add_user
 
 load_dotenv()
 set_up_logger()
@@ -28,7 +32,18 @@ frontend_url = getenv("FRONTEND_URL")
 assert frontend_url, "FRONTEND_URL must be set"
 origins = [frontend_url]
 
-app = FastAPI()
+
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    with next(get_db()) as db_session:
+        admin_password = getenv("ADMIN_PASSWORD")
+        assert admin_password, "ADMIN_PASSWORD must be set"
+        add_user("admin@domain.com", admin_password, UserRole.ADMIN, db_session)
+
+    yield
+
+
+app = FastAPI(lifespan=lifespan)
 
 
 @app.exception_handler(RefreshTokenAuthenticationError)

--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -1,3 +1,4 @@
+import logging
 from contextlib import asynccontextmanager
 from os import getenv
 
@@ -20,7 +21,7 @@ from src.api import (
     statistics,
 )
 from src.db import get_db
-from src.db.models import UserRole
+from src.db.models import User, UserRole
 from src.exceptions import RefreshTokenAuthenticationError
 from src.log import set_up_logger
 from src.util import add_user
@@ -33,12 +34,19 @@ assert frontend_url, "FRONTEND_URL must be set"
 origins = [frontend_url]
 
 
+# Add an admin user on startup
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     with next(get_db()) as db_session:
+        admin_email = "admin@domain.com"
         admin_password = getenv("ADMIN_PASSWORD")
+
         assert admin_password, "ADMIN_PASSWORD must be set"
-        add_user("admin@domain.com", admin_password, UserRole.ADMIN, db_session)
+
+        if User.filter_by(db_session, email=admin_email).first():
+            logging.info("Admin user already exists")
+        else:
+            add_user(admin_email, admin_password, UserRole.ADMIN, db_session)
 
     yield
 

--- a/backend/src/util.py
+++ b/backend/src/util.py
@@ -4,7 +4,14 @@ from fastapi import Request
 from sqlalchemy.orm import Session, contains_eager
 
 from src.auth.jwt import decode_jwt
-from src.db.models import Card, Category, Deck, User
+from src.db.models import Card, Category, Deck, User, UserRole
+
+
+def add_user(email: str, password: str, role: UserRole, db_session: Session) -> User:
+    user = User(email=email, role=role)
+    user.set_password(password)
+    user = user.save(db_session)
+    return user
 
 
 def get_user_deck(deck_id: UUID, user_id: UUID, db_session: Session) -> Deck:

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -62,7 +62,7 @@ async def client(client_factory):
 
 @pytest.fixture
 def admin(db_session):
-    email = "admin@domain.com"
+    email = "test_admin@domain.com"
     password = "password"
 
     pw_bytes = password.encode("utf-8")
@@ -78,7 +78,7 @@ async def admin_client(admin, client_factory):
     res = await client.post(
         "/auth/login",
         json={
-            "email": "admin@domain.com",
+            "email": "test_admin@domain.com",
             "password": "password",
         },
     )

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,23 @@
 services:
+  migrate:
+    build:
+      context: backend
+      target: development
+    container_name: repeater-migration
+
+    depends_on:
+      db:
+        condition: service_healthy
+
+    environment:
+      - DATABASE_URL=postgresql://user:password@db:5432/repeater
+
+    command: alembic upgrade head
+    healthcheck:
+      test: ["CMD", "echo", "migration complete"]
+      interval: 1s
+      retries: 1
+
   backend:
     build:
       context: backend
@@ -18,6 +37,7 @@ services:
       - DATABASE_URL=postgresql://user:password@db:5432/repeater
       - SECRET_KEY=abc123
       - FRONTEND_URL=http://localhost:3000
+      - ADMIN_PASSWORD=password
 
     develop:
       watch:
@@ -33,6 +53,8 @@ services:
     depends_on:
       db:
         condition: service_healthy
+      migrate:
+        condition: service_completed_successfully
 
   web:
     build:


### PR DESCRIPTION
We currently only add the admin user in the bootstrap script, and the bootstrap script only runs locally

But we need an admin user in all environments, not just locally

This adds an event to the start of the app to add an admin user if they dont already exist

This also moves the database migration step to the docker compose and runs it after the database starts