### PR TITLE
Order/sort items returned by API in a logical way

### DIFF
--- a/backend/src/api/cards.py
+++ b/backend/src/api/cards.py
@@ -49,7 +49,11 @@ def get_cards(
         query = query.filter(Card.deck_id == deck_id)
 
     if only_due:
-        query = query.filter(Card.next_review_date <= datetime.now(timezone.utc))
+        query = query.filter(
+            Card.next_review_date <= datetime.now(timezone.utc)
+        ).order_by(Card.next_review_date)
+    else:
+        query = query.order_by(Card.created_at.desc())
 
     cards = query.all()
     return [CardOut.from_card(card) for card in cards]

--- a/backend/src/api/decks.py
+++ b/backend/src/api/decks.py
@@ -50,7 +50,7 @@ def get_decks(
     user: User = Depends(get_current_user),
     db_session: Session = Depends(get_db),
 ):
-    query = db_session.query(Deck).filter(Deck.user_id == user.id)
+    query = db_session.query(Deck).filter(Deck.user_id == user.id).order_by(Deck.name)
 
     if category_id:
         query = query.filter(Deck.category_id == category_id)

--- a/backend/tests/integration/test_cards.py
+++ b/backend/tests/integration/test_cards.py
@@ -94,32 +94,12 @@ async def test_get_cards(user, user_client):
 
     res = await user_client.get("/cards")
     assert res.status_code == 200
-    assert sorted(res.json(), key=lambda c: c["created_at"]) == [
+    assert res.json() == [
         {
             "id": is_uuid_string(),
             "deck_id": deck_id,
             "deck_name": "deck",
-            "content": "Test card 1",
-            "next_review_date": is_utc_isoformat_string(),
-            "overdue": False,
-            "created_at": is_utc_isoformat_string(),
-            "updated_at": is_utc_isoformat_string(),
-        },
-        {
-            "id": is_uuid_string(),
-            "deck_id": deck_id,
-            "deck_name": "deck",
-            "content": "Test card 2",
-            "next_review_date": is_utc_isoformat_string(),
-            "overdue": False,
-            "created_at": is_utc_isoformat_string(),
-            "updated_at": is_utc_isoformat_string(),
-        },
-        {
-            "id": is_uuid_string(),
-            "deck_id": deck_id,
-            "deck_name": "deck",
-            "content": "Test card 3",
+            "content": "Test card 5",
             "next_review_date": is_utc_isoformat_string(),
             "overdue": False,
             "created_at": is_utc_isoformat_string(),
@@ -139,7 +119,27 @@ async def test_get_cards(user, user_client):
             "id": is_uuid_string(),
             "deck_id": deck_id,
             "deck_name": "deck",
-            "content": "Test card 5",
+            "content": "Test card 3",
+            "next_review_date": is_utc_isoformat_string(),
+            "overdue": False,
+            "created_at": is_utc_isoformat_string(),
+            "updated_at": is_utc_isoformat_string(),
+        },
+        {
+            "id": is_uuid_string(),
+            "deck_id": deck_id,
+            "deck_name": "deck",
+            "content": "Test card 2",
+            "next_review_date": is_utc_isoformat_string(),
+            "overdue": False,
+            "created_at": is_utc_isoformat_string(),
+            "updated_at": is_utc_isoformat_string(),
+        },
+        {
+            "id": is_uuid_string(),
+            "deck_id": deck_id,
+            "deck_name": "deck",
+            "content": "Test card 1",
             "next_review_date": is_utc_isoformat_string(),
             "overdue": False,
             "created_at": is_utc_isoformat_string(),
@@ -238,7 +238,7 @@ async def test_get_due_cards(db_session, user, user_client):
 
     # Cards should be scheduled for review as soon as they're created
     res = await user_client.get("/cards", params={"only_due": True})
-    assert sorted(res.json(), key=lambda c: c["created_at"]) == [
+    assert res.json() == [
         {
             "id": card_1_id,
             "deck_id": deck_1_id,

--- a/backend/tests/integration/test_categories.py
+++ b/backend/tests/integration/test_categories.py
@@ -65,17 +65,7 @@ async def test_get_categories(user_client):
     child_id = res.json()["id"]
 
     res = await user_client.get("/categories")
-    assert sorted(res.json(), key=lambda c: c["created_at"]) == [
-        {
-            "id": parent_id,
-            "user_id": is_uuid_string(),
-            "name": "parent",
-            "description": None,
-            "parent_id": None,
-            "is_root": True,
-            "created_at": is_utc_isoformat_string(),
-            "updated_at": is_utc_isoformat_string(),
-        },
+    assert res.json() == [
         {
             "id": child_id,
             "user_id": is_uuid_string(),
@@ -83,6 +73,16 @@ async def test_get_categories(user_client):
             "description": None,
             "parent_id": parent_id,
             "is_root": False,
+            "created_at": is_utc_isoformat_string(),
+            "updated_at": is_utc_isoformat_string(),
+        },
+        {
+            "id": parent_id,
+            "user_id": is_uuid_string(),
+            "name": "parent",
+            "description": None,
+            "parent_id": None,
+            "is_root": True,
             "created_at": is_utc_isoformat_string(),
             "updated_at": is_utc_isoformat_string(),
         },
@@ -269,7 +269,7 @@ async def test_user_can_only_see_own_categories(user_client, admin_client):
     assert res.status_code == 201
 
     res = await user_client.get("/categories")
-    assert sorted(res.json(), key=lambda c: c["created_at"]) == [
+    assert res.json() == [
         {
             "id": is_uuid_string(),
             "user_id": is_uuid_string(),


### PR DESCRIPTION
We should probably add a way to sort the responses in the future but for now:

- cards: created_at desceding (latest cards first)
- due cards: next_review_date ascending (most overdue cards appear first)
- decks: name ascending (alphabetical order)
- categories: name ascending (alphabetical order)