### PR TITLE
feat: improve flows on account change

### DIFF
--- a/web/src/app/login/page.tsx
+++ b/web/src/app/login/page.tsx
@@ -45,6 +45,7 @@ export default function Login() {
             }),
         onSuccess: () => {
             queryClient.invalidateQueries({ queryKey: ['me'] });
+            queryClient.invalidateQueries({ queryKey: ['decks'] });
             loginForm.reset();
             router.push('/review');
         },

--- a/web/src/app/register/page.tsx
+++ b/web/src/app/register/page.tsx
@@ -1,7 +1,8 @@
 'use client';
 
 import { zodResolver } from '@hookform/resolvers/zod';
-import { useMutation } from '@tanstack/react-query';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { useRouter } from 'next/navigation';
 import { useForm } from 'react-hook-form';
 import { z } from 'zod';
 
@@ -21,6 +22,8 @@ import { registerAuthRegisterPost, UserCreate } from '@/gen';
 export default function Register() {
     const apiURL = process.env.NEXT_PUBLIC_API_URL ?? '';
     const googleOAuthURI = '/oauth/login';
+    const queryClient = useQueryClient();
+    const router = useRouter();
 
     const registerFormSchema = z.object({
         email: z.string().email(),
@@ -41,7 +44,10 @@ export default function Register() {
                 body: values,
             }),
         onSuccess: () => {
+            queryClient.invalidateQueries({ queryKey: ['me'] });
+            queryClient.invalidateQueries({ queryKey: ['decks'] });
             registerForm.reset();
+            router.push('/decks');
         },
     });
 

--- a/web/src/components/nav/nav-profile.tsx
+++ b/web/src/components/nav/nav-profile.tsx
@@ -32,6 +32,7 @@ export function NavProfile() {
         mutationFn: () => logoutAuthLogoutPost(),
         onSuccess: () => {
             queryClient.invalidateQueries({ queryKey: ['me'] });
+            queryClient.invalidateQueries({ queryKey: ['decks'] });
             router.push('/login');
         },
         onError: () => {


### PR DESCRIPTION
When signing in, signing up or logging out, invalidate the 'decks' key to ensure the sidebar stays up to date.

Also redirects /register to /review on sign-up. Could be a smarter redirect in the future that checks if you have cards to review and otherwise sends you to a potential /home page or triggers a deck creation flow.