### PR TITLE
Attempt to fix infinite reload

### DIFF
--- a/backend/src/auth/jwt.py
+++ b/backend/src/auth/jwt.py
@@ -18,7 +18,7 @@ GUEST_REFRESH_TOKEN_EXPIRE_SECONDS = 60 * 60 * 24 * 30  # 30 days
 
 # TODO change the secure flag to True in production
 def get_access_token_cookie_kwargs(
-    access_token: str, exp_delta_seconds: int = REFRESH_TOKEN_EXPIRE_SECONDS
+    access_token: str, exp_delta_seconds: int = ACCESS_TOKEN_EXPIRE_SECONDS
 ) -> dict:
     return dict(
         key="access_token",
@@ -95,16 +95,15 @@ def create_guest_user(db_session: Session) -> User:
 def get_current_user(
     response: Response,
     access_token: str | None = Cookie(default=None),
+    refresh_token: str | None = Cookie(default=None),
     db_session: Session = Depends(get_db),
 ) -> User:
-    if access_token is None:
+    if access_token is None and refresh_token is None:
         guest_user = create_guest_user(db_session)
-
         access_token = create_access_token(guest_user)
         refresh_token = create_refresh_token(
             guest_user, GUEST_REFRESH_TOKEN_EXPIRE_SECONDS
         )
-
         response.set_cookie(**get_access_token_cookie_kwargs(access_token))
         response.set_cookie(
             **get_refresh_token_cookie_kwargs(
@@ -113,15 +112,15 @@ def get_current_user(
         )
         return guest_user
 
-    try:
-        payload = decode_jwt(access_token)
-        user_id = payload.get("sub")
-        if user_id is None:
-            raise HTTPException(status_code=401, detail="Invalid token")
+    if access_token:
+        try:
+            payload = decode_jwt(access_token)
+            user_id = payload.get("sub")
+            if user_id:
+                user = User.get(db_session, user_id)
+                if user:
+                    return user
+        except jwt.InvalidTokenError:
+            pass
 
-        user = User.get(db_session, user_id)
-        if user:
-            return user
-        raise HTTPException(status_code=401, detail="Invalid token")
-    except jwt.InvalidTokenError:
-        raise HTTPException(status_code=401, detail="Invalid token")
+    raise HTTPException(status_code=401, detail="Invalid or expired access token")

--- a/web/src/lib/api-client.ts
+++ b/web/src/lib/api-client.ts
@@ -15,12 +15,17 @@ client.interceptors.response.use(
     async (response: Response, request: Request) => {
         if (response.status === 401 && !isRefreshing) {
             isRefreshing = true;
-
             try {
-                await refreshTokenAuthRefreshPost();
+                const refreshResponse = await refreshTokenAuthRefreshPost();
+
+                if (refreshResponse.response && !refreshResponse.response.ok) {
+                    window.location.replace('/login');
+                    throw new Error('Refresh error');
+                }
+
                 return await fetch(request.clone());
             } catch (refreshError) {
-                window.location.href = '/login';
+                window.location.replace('/login');
                 throw refreshError;
             } finally {
                 isRefreshing = false;


### PR DESCRIPTION
sometimes when the refresh token was expired the web client got stuck in an infinite reload, this fixes that i think

1. for some reason access  token had the same expiration time as refresh token
2. interceptor didnt work that well