### PR TITLE
feat: add deck import

### DIFF
--- a/backend/src/schemas/deck.py
+++ b/backend/src/schemas/deck.py
@@ -17,7 +17,7 @@ class DeckOut(BaseModel):
     user_id: UUID
     parent_id: Optional[UUID] = None
     name: str
-    description: str
+    description: Optional[str] = None
     is_paused: bool
     is_archived: bool
     is_root: bool

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -82,6 +82,14 @@ paths:
           - type: string
           - type: 'null'
           title: Access Token
+      - name: refresh_token
+        in: cookie
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Refresh Token
       requestBody:
         required: true
         content:
@@ -136,6 +144,14 @@ paths:
           - type: string
           - type: 'null'
           title: Access Token
+      - name: refresh_token
+        in: cookie
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Refresh Token
       responses:
         '200':
           description: Successful Response
@@ -167,6 +183,14 @@ paths:
           - type: string
           - type: 'null'
           title: Access Token
+      - name: refresh_token
+        in: cookie
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Refresh Token
       responses:
         '200':
           description: Successful Response
@@ -202,6 +226,14 @@ paths:
           - type: string
           - type: 'null'
           title: Access Token
+      - name: refresh_token
+        in: cookie
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Refresh Token
       responses:
         '200':
           description: Successful Response
@@ -236,6 +268,14 @@ paths:
           - type: string
           - type: 'null'
           title: Access Token
+      - name: refresh_token
+        in: cookie
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Refresh Token
       requestBody:
         required: true
         content:
@@ -276,6 +316,14 @@ paths:
           - type: string
           - type: 'null'
           title: Access Token
+      - name: refresh_token
+        in: cookie
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Refresh Token
       responses:
         '200':
           description: Successful Response
@@ -309,6 +357,14 @@ paths:
           - type: string
           - type: 'null'
           title: Access Token
+      - name: refresh_token
+        in: cookie
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Refresh Token
       requestBody:
         required: true
         content:
@@ -356,6 +412,14 @@ paths:
           - type: string
           - type: 'null'
           title: Access Token
+      - name: refresh_token
+        in: cookie
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Refresh Token
       responses:
         '200':
           description: A downloadable JSON file
@@ -385,6 +449,14 @@ paths:
           - type: string
           - type: 'null'
           title: Access Token
+      - name: refresh_token
+        in: cookie
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Refresh Token
       requestBody:
         required: true
         content:
@@ -446,6 +518,14 @@ paths:
           - type: string
           - type: 'null'
           title: Access Token
+      - name: refresh_token
+        in: cookie
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Refresh Token
       responses:
         '200':
           description: Successful Response
@@ -484,6 +564,14 @@ paths:
           - type: string
           - type: 'null'
           title: Access Token
+      - name: refresh_token
+        in: cookie
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Refresh Token
       requestBody:
         required: true
         content:
@@ -524,6 +612,14 @@ paths:
           - type: string
           - type: 'null'
           title: Access Token
+      - name: refresh_token
+        in: cookie
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Refresh Token
       responses:
         '200':
           description: Successful Response
@@ -577,6 +673,14 @@ paths:
           - type: string
           - type: 'null'
           title: Access Token
+      - name: refresh_token
+        in: cookie
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Refresh Token
       responses:
         '200':
           description: Successful Response
@@ -605,6 +709,14 @@ paths:
           - type: string
           - type: 'null'
           title: Access Token
+      - name: refresh_token
+        in: cookie
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Refresh Token
       requestBody:
         required: true
         content:
@@ -646,6 +758,14 @@ paths:
           - type: string
           - type: 'null'
           title: Access Token
+      - name: refresh_token
+        in: cookie
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Refresh Token
       responses:
         '200':
           description: Successful Response
@@ -677,6 +797,14 @@ paths:
           - type: string
           - type: 'null'
           title: Access Token
+      - name: refresh_token
+        in: cookie
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Refresh Token
       responses:
         '200':
           description: Successful Response
@@ -712,6 +840,14 @@ paths:
           - type: string
           - type: 'null'
           title: Access Token
+      - name: refresh_token
+        in: cookie
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Refresh Token
       responses:
         '200':
           description: Successful Response
@@ -780,6 +916,14 @@ paths:
           - type: string
           - type: 'null'
           title: Access Token
+      - name: refresh_token
+        in: cookie
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Refresh Token
       responses:
         '200':
           description: Successful Response
@@ -949,7 +1093,9 @@ components:
           type: string
           title: Name
         description:
-          type: string
+          anyOf:
+          - type: string
+          - type: 'null'
           title: Description
         is_paused:
           type: boolean
@@ -978,7 +1124,6 @@ components:
       - id
       - user_id
       - name
-      - description
       - is_paused
       - is_archived
       - is_root

--- a/web/package.json
+++ b/web/package.json
@@ -45,6 +45,7 @@
         "platejs": "^49.2.4",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
+        "react-dropzone": "^14.3.8",
         "react-hook-form": "^7.59.0",
         "react-hotkeys-hook": "^5.1.0",
         "react-markdown": "^10.1.0",

--- a/web/pnpm-lock.yaml
+++ b/web/pnpm-lock.yaml
@@ -107,6 +107,9 @@ importers:
       react-dom:
         specifier: ^19.0.0
         version: 19.1.0(react@19.1.0)
+      react-dropzone:
+        specifier: ^14.3.8
+        version: 14.3.8(react@19.1.0)
       react-hook-form:
         specifier: ^7.59.0
         version: 7.59.0(react@19.1.0)
@@ -1514,6 +1517,10 @@ packages:
     resolution: {integrity: sha512-hsU18Ae8CDTR6Kgu9DYf0EbCr/a5iGL0rytQDobUcdpYOKokk8LEjVphnXkDkgpi0wYVsqrXuP0bZxJaTqdgoA==}
     engines: {node: '>= 0.4'}
 
+  attr-accept@2.2.5:
+    resolution: {integrity: sha512-0bDNnY/u6pPwHDMoF0FieU354oBi0a8rD9FcsLwzcGWbc8KS8KPIi7y+s13OlVY+gMWc/9xEMUgNE6Qm8ZllYQ==}
+    engines: {node: '>=4'}
+
   available-typed-arrays@1.0.7:
     resolution: {integrity: sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==}
     engines: {node: '>= 0.4'}
@@ -2009,6 +2016,10 @@ packages:
   file-entry-cache@8.0.0:
     resolution: {integrity: sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==}
     engines: {node: '>=16.0.0'}
+
+  file-selector@2.1.2:
+    resolution: {integrity: sha512-QgXo+mXTe8ljeqUFaX3QVHc5osSItJ/Km+xpocx0aSqWGMSCf6qYs/VnzZgS864Pjn5iceMRFigeAV7AfTlaig==}
+    engines: {node: '>= 12'}
 
   fill-range@7.1.1:
     resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
@@ -2984,6 +2995,12 @@ packages:
     resolution: {integrity: sha512-Xs1hdnE+DyKgeHJeJznQmYMIBG3TKIHJJT95Q58nHLSrElKlGQqDTR2HQ9fx5CN/Gk6Vh/kupBTDLU11/nDk/g==}
     peerDependencies:
       react: ^19.1.0
+
+  react-dropzone@14.3.8:
+    resolution: {integrity: sha512-sBgODnq+lcA4P296DY4wacOZz3JFpD99fp+hb//iBO2HHnyeZU3FwWyXJ6salNpqQdsZrgMrotuko/BdJMV8Ug==}
+    engines: {node: '>= 10.13'}
+    peerDependencies:
+      react: '>= 16.8 || 18.0.0'
 
   react-hook-form@7.59.0:
     resolution: {integrity: sha512-kmkek2/8grqarTJExFNjy+RXDIP8yM+QTl3QL6m6Q8b2bih4ltmiXxH7T9n+yXNK477xPh5yZT/6vD8sYGzJTA==}
@@ -4906,6 +4923,8 @@ snapshots:
 
   async-function@1.0.0: {}
 
+  attr-accept@2.2.5: {}
+
   available-typed-arrays@1.0.7:
     dependencies:
       possible-typed-array-names: 1.1.0
@@ -5532,6 +5551,10 @@ snapshots:
   file-entry-cache@8.0.0:
     dependencies:
       flat-cache: 4.0.1
+
+  file-selector@2.1.2:
+    dependencies:
+      tslib: 2.8.1
 
   fill-range@7.1.1:
     dependencies:
@@ -6637,6 +6660,13 @@ snapshots:
     dependencies:
       react: 19.1.0
       scheduler: 0.26.0
+
+  react-dropzone@14.3.8(react@19.1.0):
+    dependencies:
+      attr-accept: 2.2.5
+      file-selector: 2.1.2
+      prop-types: 15.8.1
+      react: 19.1.0
 
   react-hook-form@7.59.0(react@19.1.0):
     dependencies:

--- a/web/src/components/nav/add-deck-dropdown.tsx
+++ b/web/src/components/nav/add-deck-dropdown.tsx
@@ -17,6 +17,35 @@ import {
 import { importDeckDecksImportPost } from '@/gen/sdk.gen';
 import { ImportFormat } from '@/gen/types.gen';
 
+const IMPORT_FORMATS = {
+    repeater: {
+        id: 'repeater' as ImportFormat,
+        name: 'Repeater',
+        accept: { 'application/json': ['.json'] },
+        available: true,
+    },
+    mochi_markdown: {
+        id: 'mochi_markdown' as ImportFormat,
+        name: 'Mochi (markdown)',
+        accept: { 'text/markdown': ['.md'], 'application/zip': ['.zip'] },
+        available: true,
+    },
+    mochi: {
+        id: 'mochi' as ImportFormat,
+        name: 'Mochi (.mochi)',
+        accept: { 'application/octet-stream': ['.mochi'] },
+        available: false,
+    },
+    anki: {
+        id: 'anki' as ImportFormat,
+        name: 'Anki',
+        accept: { 'application/x-sqlite3': ['.apkg'] },
+        available: false,
+    },
+} as const;
+
+type ImportFormatConfig = (typeof IMPORT_FORMATS)[keyof typeof IMPORT_FORMATS];
+
 export function AddDeckDropdown({
     trigger,
     side,
@@ -34,7 +63,8 @@ export function AddDeckDropdown({
     const queryClient = useQueryClient();
 
     const [dropdownState, setDropdownState] = useState(DropdownState.Initial);
-    const [importFormat, setImportFormat] = useState<ImportFormat | null>(null);
+    const [selectedFormat, setSelectedFormat] =
+        useState<ImportFormatConfig | null>(null);
     const [deckName, setDeckName] = useState('');
     const [deckDescription, setDeckDescription] = useState('');
     const [files, setFiles] = useState<File[]>();
@@ -132,55 +162,39 @@ export function AddDeckDropdown({
                             Import deck
                         </DropdownMenuLabel>
                         <div className="flex flex-col gap-2 p-2">
-                            <Button
-                                variant="outline"
-                                className="flex justify-start"
-                                onClick={() => {
-                                    setImportFormat('repeater');
-                                    setDropdownState(
-                                        DropdownState.ImportUpload
-                                    );
-                                }}
-                            >
-                                Repeater
-                            </Button>
-                            <Button
-                                variant="outline"
-                                className="flex justify-start"
-                                onClick={() => {
-                                    setImportFormat('mochi_markdown');
-                                    setDropdownState(
-                                        DropdownState.ImportUpload
-                                    );
-                                }}
-                            >
-                                Mochi (markdown)
-                            </Button>
-                            <Button
-                                variant="outline"
-                                className="relative flex justify-start"
-                                disabled
-                            >
-                                Mochi (.mochi)
-                                <div className="bg-primary text-primary-foreground absolute -top-1 -right-1 rounded-md px-1.5 py-0.5 text-[0.5rem]">
-                                    SOON
-                                </div>
-                            </Button>
-                            <Button
-                                variant="outline"
-                                className="relative flex justify-start"
-                                disabled
-                            >
-                                Anki
-                                <div className="bg-primary text-primary-foreground absolute -top-1 -right-1 rounded-md px-1.5 py-0.5 text-[0.5rem]">
-                                    SOON
-                                </div>
-                            </Button>
+                            {Object.values(IMPORT_FORMATS).map((format) => (
+                                <Button
+                                    key={format.id}
+                                    variant="outline"
+                                    className={
+                                        format.available
+                                            ? 'flex justify-start'
+                                            : 'relative flex justify-start'
+                                    }
+                                    disabled={!format.available}
+                                    onClick={() => {
+                                        if (format.available) {
+                                            setSelectedFormat(format);
+                                            setDropdownState(
+                                                DropdownState.ImportUpload
+                                            );
+                                        }
+                                    }}
+                                >
+                                    {format.name}
+                                    {!format.available && (
+                                        <div className="bg-primary text-primary-foreground absolute -top-1 -right-1 rounded-md px-1.5 py-0.5 text-[0.5rem]">
+                                            SOON
+                                        </div>
+                                    )}
+                                </Button>
+                            ))}
                             <Button
                                 variant="secondary"
                                 onClick={(e) => {
                                     e.preventDefault();
                                     setDropdownState(DropdownState.Initial);
+                                    setSelectedFormat(null);
                                 }}
                             >
                                 Back
@@ -188,74 +202,85 @@ export function AddDeckDropdown({
                         </div>
                     </>
                 )}
-                {dropdownState === DropdownState.ImportUpload && (
-                    <>
-                        <DropdownMenuLabel className="text-muted-foreground">
-                            Import deck / Upload
-                        </DropdownMenuLabel>
-                        <div className="flex flex-col gap-2 p-2">
-                            <Dropzone
-                                accept={{
-                                    'application/zip': ['.zip'],
-                                    'text/markdown': ['.md'],
-                                }}
-                                maxFiles={1}
-                                maxSize={1024 * 1024 * 50}
-                                onDrop={(files: File[]) => {
-                                    setFiles(files);
-                                    console.log(files);
-                                }}
-                                onError={console.error} // TODO: add proper error handling
-                                src={files}
-                            >
-                                <DropzoneEmptyState />
-                                <DropzoneContent />
-                            </Dropzone>
-
-                            <div className="flex gap-2">
-                                <Button
-                                    className="flex-1"
-                                    variant="secondary"
-                                    onClick={(e) => {
-                                        e.preventDefault();
-                                        setDropdownState(DropdownState.Import);
-                                        setFiles([]);
+                {dropdownState === DropdownState.ImportUpload &&
+                    selectedFormat && (
+                        <>
+                            <DropdownMenuLabel className="text-muted-foreground">
+                                Import {selectedFormat.name}
+                            </DropdownMenuLabel>
+                            <div className="flex flex-col gap-2 p-2">
+                                <Dropzone
+                                    accept={selectedFormat.accept}
+                                    maxFiles={1}
+                                    maxSize={1024 * 1024 * 50}
+                                    onDrop={(files: File[]) => {
+                                        setFiles(files);
+                                        console.log(files);
                                     }}
+                                    onError={console.error} // TODO: add proper error handling
+                                    src={files}
                                 >
-                                    Back
-                                </Button>
-                                <Button
-                                    className="flex-1"
-                                    onClick={async (e) => {
-                                        e.preventDefault();
-                                        if (!files?.length || !importFormat) {
-                                            return;
-                                        }
+                                    <DropzoneEmptyState />
+                                    <DropzoneContent />
+                                </Dropzone>
 
-                                        try {
-                                            await importDeckDecksImportPost({
-                                                body: { file: files[0] },
-                                                query: { format: importFormat },
-                                            });
-                                            queryClient.invalidateQueries({
-                                                queryKey: ['decks'],
-                                            });
-                                            // TODO: Add success handling (e.g., refresh decks list, close dropdown)
-                                        } catch (error) {
-                                            // TODO: Add error handling
-                                            console.error(
-                                                'Import failed:',
-                                                error
+                                <div className="flex gap-2">
+                                    <Button
+                                        className="flex-1"
+                                        variant="secondary"
+                                        onClick={(e) => {
+                                            e.preventDefault();
+                                            setDropdownState(
+                                                DropdownState.Import
                                             );
-                                        }
-                                    }}
-                                >
-                                    Import
-                                </Button>
+                                            setFiles([]);
+                                        }}
+                                    >
+                                        Back
+                                    </Button>
+                                    <Button
+                                        className="flex-1"
+                                        onClick={async (e) => {
+                                            e.preventDefault();
+                                            if (
+                                                !files?.length ||
+                                                !selectedFormat
+                                            ) {
+                                                return;
+                                            }
+
+                                            try {
+                                                await importDeckDecksImportPost(
+                                                    {
+                                                        body: {
+                                                            file: files[0],
+                                                        },
+                                                        query: {
+                                                            format: selectedFormat.id,
+                                                        },
+                                                    }
+                                                );
+                                                setFiles([]);
+                                                setSelectedFormat(null);
+                                                queryClient.invalidateQueries({
+                                                    queryKey: ['decks'],
+                                                });
+                                                // TODO: close dropdown
+                                            } catch (error) {
+                                                // TODO: Add error handling
+                                                console.error(
+                                                    'Import failed:',
+                                                    error
+                                                );
+                                            }
+                                        }}
+                                    >
+                                        Import
+                                    </Button>
+                                </div>
                             </div>
-                        </div>
-                    </>
-                )}
+                        </>
+                    )}
             </DropdownMenuContent>
         </DropdownMenu>
     );

--- a/web/src/components/nav/add-deck-dropdown.tsx
+++ b/web/src/components/nav/add-deck-dropdown.tsx
@@ -1,0 +1,243 @@
+import { useState } from 'react';
+
+import { Button } from '@/components/ui/button';
+import {
+    DropdownMenu,
+    DropdownMenuContent,
+    DropdownMenuTrigger,
+    DropdownMenuLabel,
+} from '@/components/ui/dropdown-menu';
+import { Input } from '@/components/ui/input';
+import {
+    Dropzone,
+    DropzoneContent,
+    DropzoneEmptyState,
+} from '@/components/ui/shadcn-io/dropzone';
+
+export function AddDeckDropdown({
+    trigger,
+    side,
+}: {
+    trigger?: React.ReactNode;
+    side?: 'top' | 'right' | 'bottom' | 'left';
+}) {
+    enum DropdownState {
+        Initial,
+        Creation,
+        Import,
+        ImportUpload,
+    }
+
+    enum ImportFormat {
+        Repeater = 'repeater',
+        MochiMarkdown = 'mochi_markdown',
+    }
+
+    const [dropdownState, setDropdownState] = useState(DropdownState.Initial);
+    const [_, setImportFormat] = useState<ImportFormat | null>(null);
+    const [deckName, setDeckName] = useState('');
+    const [deckDescription, setDeckDescription] = useState('');
+    const [files, setFiles] = useState<File[]>();
+
+    return (
+        <DropdownMenu>
+            <DropdownMenuTrigger asChild>{trigger}</DropdownMenuTrigger>
+            <DropdownMenuContent side={side}>
+                {dropdownState === DropdownState.Initial && (
+                    <>
+                        <div className="flex flex-col gap-2 p-2">
+                            <Button
+                                variant="outline"
+                                onClick={(e) => {
+                                    e.preventDefault();
+                                    setDropdownState(DropdownState.Creation);
+                                }}
+                            >
+                                Create deck
+                            </Button>
+                            <Button
+                                variant="outline"
+                                onClick={(e) => {
+                                    e.preventDefault();
+                                    setDropdownState(DropdownState.Import);
+                                }}
+                            >
+                                Import deck
+                            </Button>
+                        </div>
+                    </>
+                )}
+                {dropdownState === DropdownState.Creation && (
+                    <>
+                        <DropdownMenuLabel className="text-muted-foreground">
+                            Create deck
+                        </DropdownMenuLabel>
+                        <div className="flex flex-col gap-2 p-2">
+                            <div className="flex flex-col gap-2">
+                                <Input
+                                    id="deck-name"
+                                    type="text"
+                                    placeholder="Deck name"
+                                    value={deckName}
+                                    onChange={(e) =>
+                                        setDeckName(e.target.value)
+                                    }
+                                    className="w-full"
+                                />
+                            </div>
+                            <div className="flex flex-col gap-2">
+                                <Input
+                                    id="deck-description"
+                                    type="text"
+                                    placeholder="Description"
+                                    value={deckDescription}
+                                    onChange={(e) =>
+                                        setDeckDescription(e.target.value)
+                                    }
+                                    className="w-full"
+                                />
+                            </div>
+                            <div className="flex gap-2">
+                                <Button
+                                    variant="secondary"
+                                    className="flex-1"
+                                    onClick={(e) => {
+                                        e.preventDefault();
+                                        setDropdownState(DropdownState.Initial);
+                                        setDeckName('');
+                                        setDeckDescription('');
+                                    }}
+                                >
+                                    Back
+                                </Button>
+                                <Button
+                                    className="flex-1"
+                                    onClick={(e) => {
+                                        e.preventDefault();
+                                        console.log('Create deck:', {
+                                            deckName,
+                                            deckDescription,
+                                        });
+                                    }}
+                                >
+                                    Create
+                                </Button>
+                            </div>
+                        </div>
+                    </>
+                )}
+                {dropdownState === DropdownState.Import && (
+                    <>
+                        <DropdownMenuLabel className="text-muted-foreground">
+                            Import deck
+                        </DropdownMenuLabel>
+                        <div className="flex flex-col gap-2 p-2">
+                            <Button
+                                variant="outline"
+                                className="flex justify-start"
+                                onClick={() => {
+                                    setImportFormat(ImportFormat.Repeater);
+                                    setDropdownState(
+                                        DropdownState.ImportUpload
+                                    );
+                                }}
+                            >
+                                Repeater
+                            </Button>
+                            <Button
+                                variant="outline"
+                                className="flex justify-start"
+                                onClick={() => {
+                                    setImportFormat(ImportFormat.MochiMarkdown);
+                                    setDropdownState(
+                                        DropdownState.ImportUpload
+                                    );
+                                }}
+                            >
+                                Mochi (markdown)
+                            </Button>
+                            <Button
+                                variant="outline"
+                                className="relative flex justify-start"
+                                disabled
+                            >
+                                Mochi (.mochi)
+                                <div className="bg-primary text-primary-foreground absolute -top-1 -right-1 rounded-md px-1.5 py-0.5 text-[0.5rem]">
+                                    SOON
+                                </div>
+                            </Button>
+                            <Button
+                                variant="outline"
+                                className="relative flex justify-start"
+                                disabled
+                            >
+                                Anki
+                                <div className="bg-primary text-primary-foreground absolute -top-1 -right-1 rounded-md px-1.5 py-0.5 text-[0.5rem]">
+                                    SOON
+                                </div>
+                            </Button>
+                            <Button
+                                variant="secondary"
+                                onClick={(e) => {
+                                    e.preventDefault();
+                                    setDropdownState(DropdownState.Initial);
+                                }}
+                            >
+                                Back
+                            </Button>
+                        </div>
+                    </>
+                )}
+                {dropdownState === DropdownState.ImportUpload && (
+                    <>
+                        <DropdownMenuLabel className="text-muted-foreground">
+                            Import deck / Upload
+                        </DropdownMenuLabel>
+                        <div className="flex flex-col gap-2 p-2">
+                            <Dropzone
+                                accept={{
+                                    'application/zip': ['.zip'],
+                                    'text/markdown': ['.md'],
+                                }}
+                                maxFiles={1}
+                                maxSize={1024 * 1024 * 50}
+                                onDrop={(files: File[]) => {
+                                    setFiles(files);
+                                    console.log(files);
+                                }}
+                                onError={console.error} // TODO: add proper error handling
+                                src={files}
+                            >
+                                <DropzoneEmptyState />
+                                <DropzoneContent />
+                            </Dropzone>
+
+                            <div className="flex gap-2">
+                                <Button
+                                    className="flex-1"
+                                    variant="secondary"
+                                    onClick={(e) => {
+                                        e.preventDefault();
+                                        setDropdownState(DropdownState.Import);
+                                        setFiles([]);
+                                    }}
+                                >
+                                    Back
+                                </Button>
+                                <Button
+                                    className="flex-1"
+                                    onClick={(e) => {
+                                        e.preventDefault();
+                                        console.log('TODO: make import call');
+                                    }}
+                                >
+                                    Import
+                                </Button>
+                            </div>
+                        </div>
+                    </>
+                )}
+            </DropdownMenuContent>
+        </DropdownMenu>
+    );
+}

--- a/web/src/components/nav/add-deck-dropdown.tsx
+++ b/web/src/components/nav/add-deck-dropdown.tsx
@@ -1,3 +1,4 @@
+import { useQueryClient } from '@tanstack/react-query';
 import { useState } from 'react';
 
 import { Button } from '@/components/ui/button';
@@ -13,6 +14,8 @@ import {
     DropzoneContent,
     DropzoneEmptyState,
 } from '@/components/ui/shadcn-io/dropzone';
+import { importDeckDecksImportPost } from '@/gen/sdk.gen';
+import { ImportFormat } from '@/gen/types.gen';
 
 export function AddDeckDropdown({
     trigger,
@@ -28,13 +31,10 @@ export function AddDeckDropdown({
         ImportUpload,
     }
 
-    enum ImportFormat {
-        Repeater = 'repeater',
-        MochiMarkdown = 'mochi_markdown',
-    }
+    const queryClient = useQueryClient();
 
     const [dropdownState, setDropdownState] = useState(DropdownState.Initial);
-    const [_, setImportFormat] = useState<ImportFormat | null>(null);
+    const [importFormat, setImportFormat] = useState<ImportFormat | null>(null);
     const [deckName, setDeckName] = useState('');
     const [deckDescription, setDeckDescription] = useState('');
     const [files, setFiles] = useState<File[]>();
@@ -136,7 +136,7 @@ export function AddDeckDropdown({
                                 variant="outline"
                                 className="flex justify-start"
                                 onClick={() => {
-                                    setImportFormat(ImportFormat.Repeater);
+                                    setImportFormat('repeater');
                                     setDropdownState(
                                         DropdownState.ImportUpload
                                     );
@@ -148,7 +148,7 @@ export function AddDeckDropdown({
                                 variant="outline"
                                 className="flex justify-start"
                                 onClick={() => {
-                                    setImportFormat(ImportFormat.MochiMarkdown);
+                                    setImportFormat('mochi_markdown');
                                     setDropdownState(
                                         DropdownState.ImportUpload
                                     );
@@ -226,9 +226,28 @@ export function AddDeckDropdown({
                                 </Button>
                                 <Button
                                     className="flex-1"
-                                    onClick={(e) => {
+                                    onClick={async (e) => {
                                         e.preventDefault();
-                                        console.log('TODO: make import call');
+                                        if (!files?.length || !importFormat) {
+                                            return;
+                                        }
+
+                                        try {
+                                            await importDeckDecksImportPost({
+                                                body: { file: files[0] },
+                                                query: { format: importFormat },
+                                            });
+                                            queryClient.invalidateQueries({
+                                                queryKey: ['decks'],
+                                            });
+                                            // TODO: Add success handling (e.g., refresh decks list, close dropdown)
+                                        } catch (error) {
+                                            // TODO: Add error handling
+                                            console.error(
+                                                'Import failed:',
+                                                error
+                                            );
+                                        }
                                     }}
                                 >
                                     Import

--- a/web/src/components/nav/add-deck-dropdown.tsx
+++ b/web/src/components/nav/add-deck-dropdown.tsx
@@ -157,6 +157,7 @@ export function AddDeckDropdown({
                                 </Button>
                                 <Button
                                     className="flex-1"
+                                    disabled // TODO: implement
                                     onClick={(e) => {
                                         e.preventDefault();
                                         console.log('Create deck:', {
@@ -274,11 +275,6 @@ export function AddDeckDropdown({
                                             }
 
                                             const handleImport = async () => {
-                                                await new Promise((resolve) =>
-                                                    setTimeout(resolve, 3000)
-                                                );
-                                                console.log('timeout done');
-
                                                 try {
                                                     await importDeckDecksImportPost(
                                                         {

--- a/web/src/components/nav/add-deck-dropdown.tsx
+++ b/web/src/components/nav/add-deck-dropdown.tsx
@@ -1,5 +1,6 @@
 import { useQueryClient } from '@tanstack/react-query';
 import { useState } from 'react';
+import { toast } from 'sonner';
 
 import { Button } from '@/components/ui/button';
 import {
@@ -16,6 +17,7 @@ import {
 } from '@/components/ui/shadcn-io/dropzone';
 import { importDeckDecksImportPost } from '@/gen/sdk.gen';
 import { ImportFormat } from '@/gen/types.gen';
+import { getErrorMessage } from '@/lib/utils';
 
 const IMPORT_FORMATS = {
     repeater: {
@@ -53,7 +55,7 @@ export function AddDeckDropdown({
     trigger?: React.ReactNode;
     side?: 'top' | 'right' | 'bottom' | 'left';
 }) {
-    enum DropdownState {
+    enum AddDeckState {
         Initial,
         Creation,
         Import,
@@ -62,25 +64,38 @@ export function AddDeckDropdown({
 
     const queryClient = useQueryClient();
 
-    const [dropdownState, setDropdownState] = useState(DropdownState.Initial);
+    const [dropdownOpen, setDropdownOpen] = useState(false);
+    const [addDeckState, setAddDeckState] = useState(AddDeckState.Initial);
     const [selectedFormat, setSelectedFormat] =
         useState<ImportFormatConfig | null>(null);
     const [deckName, setDeckName] = useState('');
     const [deckDescription, setDeckDescription] = useState('');
-    const [files, setFiles] = useState<File[]>();
+    const [files, setFiles] = useState<File[] | undefined>();
+
+    const handleOpenChange = (open: boolean) => {
+        // Reset dropdown state when opening
+        setDropdownOpen(open);
+        if (open) {
+            setAddDeckState(AddDeckState.Initial);
+            setDeckName('');
+            setDeckDescription('');
+            setFiles(undefined);
+            setSelectedFormat(null);
+        }
+    };
 
     return (
-        <DropdownMenu>
+        <DropdownMenu open={dropdownOpen} onOpenChange={handleOpenChange}>
             <DropdownMenuTrigger asChild>{trigger}</DropdownMenuTrigger>
             <DropdownMenuContent side={side}>
-                {dropdownState === DropdownState.Initial && (
+                {addDeckState === AddDeckState.Initial && (
                     <>
                         <div className="flex flex-col gap-2 p-2">
                             <Button
                                 variant="outline"
                                 onClick={(e) => {
                                     e.preventDefault();
-                                    setDropdownState(DropdownState.Creation);
+                                    setAddDeckState(AddDeckState.Creation);
                                 }}
                             >
                                 Create deck
@@ -89,7 +104,7 @@ export function AddDeckDropdown({
                                 variant="outline"
                                 onClick={(e) => {
                                     e.preventDefault();
-                                    setDropdownState(DropdownState.Import);
+                                    setAddDeckState(AddDeckState.Import);
                                 }}
                             >
                                 Import deck
@@ -97,7 +112,7 @@ export function AddDeckDropdown({
                         </div>
                     </>
                 )}
-                {dropdownState === DropdownState.Creation && (
+                {addDeckState === AddDeckState.Creation && (
                     <>
                         <DropdownMenuLabel className="text-muted-foreground">
                             Create deck
@@ -133,7 +148,7 @@ export function AddDeckDropdown({
                                     className="flex-1"
                                     onClick={(e) => {
                                         e.preventDefault();
-                                        setDropdownState(DropdownState.Initial);
+                                        setAddDeckState(AddDeckState.Initial);
                                         setDeckName('');
                                         setDeckDescription('');
                                     }}
@@ -156,7 +171,7 @@ export function AddDeckDropdown({
                         </div>
                     </>
                 )}
-                {dropdownState === DropdownState.Import && (
+                {addDeckState === AddDeckState.Import && (
                     <>
                         <DropdownMenuLabel className="text-muted-foreground">
                             Import deck
@@ -175,8 +190,8 @@ export function AddDeckDropdown({
                                     onClick={() => {
                                         if (format.available) {
                                             setSelectedFormat(format);
-                                            setDropdownState(
-                                                DropdownState.ImportUpload
+                                            setAddDeckState(
+                                                AddDeckState.ImportUpload
                                             );
                                         }
                                     }}
@@ -193,7 +208,7 @@ export function AddDeckDropdown({
                                 variant="secondary"
                                 onClick={(e) => {
                                     e.preventDefault();
-                                    setDropdownState(DropdownState.Initial);
+                                    setAddDeckState(AddDeckState.Initial);
                                     setSelectedFormat(null);
                                 }}
                             >
@@ -202,7 +217,7 @@ export function AddDeckDropdown({
                         </div>
                     </>
                 )}
-                {dropdownState === DropdownState.ImportUpload &&
+                {addDeckState === AddDeckState.ImportUpload &&
                     selectedFormat && (
                         <>
                             <DropdownMenuLabel className="text-muted-foreground">
@@ -212,12 +227,21 @@ export function AddDeckDropdown({
                                 <Dropzone
                                     accept={selectedFormat.accept}
                                     maxFiles={1}
-                                    maxSize={1024 * 1024 * 50}
+                                    maxSize={1024 * 1024}
                                     onDrop={(files: File[]) => {
                                         setFiles(files);
                                         console.log(files);
                                     }}
-                                    onError={console.error} // TODO: add proper error handling
+                                    onError={(error) =>
+                                        toast.error(
+                                            <div>
+                                                <p>File upload failed</p>
+                                                <p className="text-xs text-muted-foreground">
+                                                    {getErrorMessage(error)}
+                                                </p>
+                                            </div>
+                                        )
+                                    }
                                     src={files}
                                 >
                                     <DropzoneEmptyState />
@@ -230,17 +254,17 @@ export function AddDeckDropdown({
                                         variant="secondary"
                                         onClick={(e) => {
                                             e.preventDefault();
-                                            setDropdownState(
-                                                DropdownState.Import
+                                            setAddDeckState(
+                                                AddDeckState.Import
                                             );
-                                            setFiles([]);
+                                            setFiles(undefined);
                                         }}
                                     >
                                         Back
                                     </Button>
                                     <Button
                                         className="flex-1"
-                                        onClick={async (e) => {
+                                        onClick={(e) => {
                                             e.preventDefault();
                                             if (
                                                 !files?.length ||
@@ -249,30 +273,54 @@ export function AddDeckDropdown({
                                                 return;
                                             }
 
-                                            try {
-                                                await importDeckDecksImportPost(
-                                                    {
-                                                        body: {
-                                                            file: files[0],
-                                                        },
-                                                        query: {
-                                                            format: selectedFormat.id,
-                                                        },
-                                                    }
+                                            const handleImport = async () => {
+                                                await new Promise((resolve) =>
+                                                    setTimeout(resolve, 3000)
                                                 );
-                                                setFiles([]);
-                                                setSelectedFormat(null);
-                                                queryClient.invalidateQueries({
-                                                    queryKey: ['decks'],
-                                                });
-                                                // TODO: close dropdown
-                                            } catch (error) {
-                                                // TODO: Add error handling
-                                                console.error(
-                                                    'Import failed:',
-                                                    error
-                                                );
-                                            }
+                                                console.log('timeout done');
+
+                                                try {
+                                                    await importDeckDecksImportPost(
+                                                        {
+                                                            body: {
+                                                                file: files[0],
+                                                            },
+                                                            query: {
+                                                                format: selectedFormat.id,
+                                                            },
+                                                        }
+                                                    );
+                                                    queryClient.invalidateQueries(
+                                                        {
+                                                            queryKey: ['decks'],
+                                                        }
+                                                    );
+                                                    setDropdownOpen(false);
+                                                } catch (error) {
+                                                    setDropdownOpen(false);
+                                                    throw error;
+                                                }
+                                            };
+
+                                            toast.promise(handleImport(), {
+                                                loading: `Importing ${files[0].name}...`,
+                                                success: `Successfully imported ${files[0].name}`,
+                                                error: (error) => (
+                                                    <div>
+                                                        <p>
+                                                            Couldn&apos;t import{' '}
+                                                            <span className="font-mono">
+                                                                {files[0].name}
+                                                            </span>
+                                                        </p>
+                                                        <p className="text-xs text-muted-foreground">
+                                                            {getErrorMessage(
+                                                                error
+                                                            )}
+                                                        </p>
+                                                    </div>
+                                                ),
+                                            });
                                         }}
                                     >
                                         Import

--- a/web/src/components/nav/app-sidebar.tsx
+++ b/web/src/components/nav/app-sidebar.tsx
@@ -6,7 +6,7 @@ import { useState } from 'react';
 
 import CardCreationDialog from '@/components/card-creation-dialog';
 import DeckCreationDialog from '@/components/deck-creation-dialog';
-import { NavDecks } from '@/components/nav/nav-decks';
+import NavDecks from '@/components/nav/nav-decks';
 import { NavProfile } from '@/components/nav/nav-profile';
 import { Button } from '@/components/ui/button';
 import {

--- a/web/src/components/nav/nav-decks.tsx
+++ b/web/src/components/nav/nav-decks.tsx
@@ -6,19 +6,6 @@ import { toast } from 'sonner';
 
 import DeckCreationDialog from '@/components/deck-creation-dialog';
 import { TreeView, TreeDataItem } from '@/components/tree-view';
-import { Button } from '@/components/ui/button';
-import {
-    DropdownMenu,
-    DropdownMenuContent,
-    DropdownMenuTrigger,
-    DropdownMenuLabel,
-} from '@/components/ui/dropdown-menu';
-import { Input } from '@/components/ui/input';
-import {
-    Dropzone,
-    DropzoneContent,
-    DropzoneEmptyState,
-} from '@/components/ui/shadcn-io/dropzone';
 import {
     SidebarMenu,
     SidebarMenuItem,
@@ -32,12 +19,14 @@ import { SidebarMenuSkeleton } from '@/components/ui/sidebar';
 import { DeckNode } from '@/gen';
 import { getDecksTreeDecksTreeGet, updateDeckDecksDeckIdPatch } from '@/gen';
 
+import { AddDeckDropdown } from './add-deck-dropdown';
+
 type MoveDeckArgs = {
     deck_id: string;
     new_parent_id: string | null;
 };
 
-export function NavDecks() {
+export default function NavDecks() {
     const [isDialogOpen, setIsDialogOpen] = useState(false);
     const [defaultParentId, setDefaultParentId] = useState<string | undefined>(
         undefined
@@ -134,7 +123,19 @@ export function NavDecks() {
                 }
                 defaultParentId={defaultParentId}
             />
-            <SidebarGroupActionAddDeckDropdown />
+
+            <AddDeckDropdown
+                trigger={
+                    <SidebarGroupAction
+                        title="Add deck"
+                        className="cursor-pointer"
+                        hidden={isError}
+                    >
+                        <Plus /> <span className="sr-only">Create deck</span>
+                    </SidebarGroupAction>
+                }
+                side={isMobile ? 'bottom' : 'right'}
+            />
             {isLoading && !isError && (
                 <SidebarMenu>
                     <>
@@ -185,246 +186,4 @@ export function NavDecks() {
             )}
         </SidebarGroup>
     );
-
-    function SidebarGroupActionAddDeckDropdown() {
-        enum DropdownState {
-            Initial,
-            Creation,
-            Import,
-            ImportUpload,
-        }
-
-        enum ImportFormat {
-            Repeater = 'repeater',
-            MochiMarkdown = 'mochi_markdown',
-        }
-
-        const [dropdownState, setDropdownState] = useState(
-            DropdownState.Initial
-        );
-        const [_, setImportFormat] = useState<ImportFormat | null>(null);
-        const [deckName, setDeckName] = useState('');
-        const [deckDescription, setDeckDescription] = useState('');
-        const [files, setFiles] = useState<File[]>();
-
-        return (
-            <DropdownMenu>
-                <DropdownMenuTrigger asChild>
-                    <SidebarGroupAction
-                        title="Add deck"
-                        className="cursor-pointer"
-                        hidden={isError}
-                    >
-                        <Plus /> <span className="sr-only">Create deck</span>
-                    </SidebarGroupAction>
-                </DropdownMenuTrigger>
-                <DropdownMenuContent side={isMobile ? 'bottom' : 'right'}>
-                    {dropdownState === DropdownState.Initial && (
-                        <>
-                            <div className="flex flex-col gap-2 p-2">
-                                <Button
-                                    variant="outline"
-                                    onClick={(e) => {
-                                        e.preventDefault();
-                                        setDropdownState(
-                                            DropdownState.Creation
-                                        );
-                                    }}
-                                >
-                                    Create deck
-                                </Button>
-                                <Button
-                                    variant="outline"
-                                    onClick={(e) => {
-                                        e.preventDefault();
-                                        setDropdownState(DropdownState.Import);
-                                    }}
-                                >
-                                    Import deck
-                                </Button>
-                            </div>
-                        </>
-                    )}
-                    {dropdownState === DropdownState.Creation && (
-                        <>
-                            <DropdownMenuLabel className="text-muted-foreground">
-                                Create deck
-                            </DropdownMenuLabel>
-                            <div className="flex flex-col gap-2 p-2">
-                                <div className="flex flex-col gap-2">
-                                    <Input
-                                        id="deck-name"
-                                        type="text"
-                                        placeholder="Deck name"
-                                        value={deckName}
-                                        onChange={(e) =>
-                                            setDeckName(e.target.value)
-                                        }
-                                        className="w-full"
-                                    />
-                                </div>
-                                <div className="flex flex-col gap-2">
-                                    <Input
-                                        id="deck-description"
-                                        type="text"
-                                        placeholder="Description"
-                                        value={deckDescription}
-                                        onChange={(e) =>
-                                            setDeckDescription(e.target.value)
-                                        }
-                                        className="w-full"
-                                    />
-                                </div>
-                                <div className="flex gap-2">
-                                    <Button
-                                        variant="secondary"
-                                        className="flex-1"
-                                        onClick={(e) => {
-                                            e.preventDefault();
-                                            setDropdownState(
-                                                DropdownState.Initial
-                                            );
-                                            setDeckName('');
-                                            setDeckDescription('');
-                                        }}
-                                    >
-                                        Back
-                                    </Button>
-                                    <Button
-                                        className="flex-1"
-                                        onClick={(e) => {
-                                            e.preventDefault();
-                                            console.log('Create deck:', {
-                                                deckName,
-                                                deckDescription,
-                                            });
-                                        }}
-                                    >
-                                        Create
-                                    </Button>
-                                </div>
-                            </div>
-                        </>
-                    )}
-                    {dropdownState === DropdownState.Import && (
-                        <>
-                            <DropdownMenuLabel className="text-muted-foreground">
-                                Import deck
-                            </DropdownMenuLabel>
-                            <div className="flex flex-col gap-2 p-2">
-                                <Button
-                                    variant="outline"
-                                    className="flex justify-start"
-                                    onClick={() => {
-                                        setImportFormat(ImportFormat.Repeater);
-                                        setDropdownState(
-                                            DropdownState.ImportUpload
-                                        );
-                                    }}
-                                >
-                                    Repeater
-                                </Button>
-                                <Button
-                                    variant="outline"
-                                    className="flex justify-start"
-                                    onClick={() => {
-                                        setImportFormat(
-                                            ImportFormat.MochiMarkdown
-                                        );
-                                        setDropdownState(
-                                            DropdownState.ImportUpload
-                                        );
-                                    }}
-                                >
-                                    Mochi (markdown)
-                                </Button>
-                                <Button
-                                    variant="outline"
-                                    className="relative flex justify-start"
-                                    disabled
-                                >
-                                    Mochi (.mochi)
-                                    <div className="bg-primary text-primary-foreground absolute -top-1 -right-1 rounded-md px-1.5 py-0.5 text-[0.5rem]">
-                                        SOON
-                                    </div>
-                                </Button>
-                                <Button
-                                    variant="outline"
-                                    className="relative flex justify-start"
-                                    disabled
-                                >
-                                    Anki
-                                    <div className="bg-primary text-primary-foreground absolute -top-1 -right-1 rounded-md px-1.5 py-0.5 text-[0.5rem]">
-                                        SOON
-                                    </div>
-                                </Button>
-                                <Button
-                                    variant="secondary"
-                                    onClick={(e) => {
-                                        e.preventDefault();
-                                        setDropdownState(DropdownState.Initial);
-                                    }}
-                                >
-                                    Back
-                                </Button>
-                            </div>
-                        </>
-                    )}
-                    {dropdownState === DropdownState.ImportUpload && (
-                        <>
-                            <DropdownMenuLabel className="text-muted-foreground">
-                                Import deck / Upload
-                            </DropdownMenuLabel>
-                            <div className="flex flex-col gap-2 p-2">
-                                <Dropzone
-                                    accept={{
-                                        'application/zip': ['.zip'],
-                                        'text/markdown': ['.md'],
-                                    }}
-                                    maxFiles={1}
-                                    maxSize={1024 * 1024 * 50}
-                                    onDrop={(files: File[]) => {
-                                        setFiles(files);
-                                        console.log(files);
-                                    }}
-                                    onError={console.error} // TODO: add proper error handling
-                                    src={files}
-                                >
-                                    <DropzoneEmptyState />
-                                    <DropzoneContent />
-                                </Dropzone>
-
-                                <div className="flex gap-2">
-                                    <Button
-                                        className="flex-1"
-                                        variant="secondary"
-                                        onClick={(e) => {
-                                            e.preventDefault();
-                                            setDropdownState(
-                                                DropdownState.Import
-                                            );
-                                            setFiles([]);
-                                        }}
-                                    >
-                                        Back
-                                    </Button>
-                                    <Button
-                                        className="flex-1"
-                                        onClick={(e) => {
-                                            e.preventDefault();
-                                            console.log(
-                                                'TODO: make import call'
-                                            );
-                                        }}
-                                    >
-                                        Import
-                                    </Button>
-                                </div>
-                            </div>
-                        </>
-                    )}
-                </DropdownMenuContent>
-            </DropdownMenu>
-        );
-    }
 }

--- a/web/src/components/nav/nav-decks.tsx
+++ b/web/src/components/nav/nav-decks.tsx
@@ -317,12 +317,37 @@ export function NavDecks() {
                                 Import deck
                             </DropdownMenuLabel>
                             <div className="flex flex-col gap-2 p-2">
-                                <Button variant="outline">Repeater</Button>
-                                <Button variant="outline">
+                                <Button
+                                    variant="outline"
+                                    className="flex justify-start"
+                                >
+                                    Repeater
+                                </Button>
+                                <Button
+                                    variant="outline"
+                                    className="flex justify-start"
+                                >
                                     Mochi (markdown)
                                 </Button>
-                                <Button variant="outline" disabled>
-                                    Mochi (soon)
+                                <Button
+                                    variant="outline"
+                                    className="relative flex justify-start"
+                                    disabled
+                                >
+                                    Mochi (.mochi)
+                                    <div className="bg-primary text-primary-foreground absolute -top-1 -right-1 rounded-md px-1 py-0.5 text-[0.5rem]">
+                                        SOON
+                                    </div>
+                                </Button>
+                                <Button
+                                    variant="outline"
+                                    className="relative flex justify-start"
+                                    disabled
+                                >
+                                    Anki
+                                    <div className="bg-primary text-primary-foreground absolute -top-1 -right-1 rounded-md px-1 py-0.5 text-[0.5rem]">
+                                        SOON
+                                    </div>
                                 </Button>
                             </div>
                         </>

--- a/web/src/components/nav/nav-decks.tsx
+++ b/web/src/components/nav/nav-decks.tsx
@@ -136,6 +136,7 @@ export default function NavDecks() {
                 }
                 side={isMobile ? 'bottom' : 'right'}
             />
+
             {isLoading && !isError && (
                 <SidebarMenu>
                     <>

--- a/web/src/components/nav/nav-decks.tsx
+++ b/web/src/components/nav/nav-decks.tsx
@@ -1,12 +1,5 @@
 import { useQuery, useQueryClient, useMutation } from '@tanstack/react-query';
-import {
-    Plus,
-    RotateCcw,
-    Folder,
-    FolderOpen,
-    ArrowRight,
-    ChevronLeft,
-} from 'lucide-react';
+import { Plus, RotateCcw, Folder, FolderOpen, ArrowRight } from 'lucide-react';
 import Link from 'next/link';
 import { useState } from 'react';
 import { toast } from 'sonner';
@@ -18,7 +11,6 @@ import {
     DropdownMenu,
     DropdownMenuContent,
     DropdownMenuTrigger,
-    DropdownMenuItem,
     DropdownMenuLabel,
 } from '@/components/ui/dropdown-menu';
 import { Input } from '@/components/ui/input';
@@ -283,7 +275,7 @@ export function NavDecks() {
                                             setDeckDescription('');
                                         }}
                                     >
-                                        Cancel
+                                        Back
                                     </Button>
                                     <Button
                                         className="flex-1"
@@ -303,16 +295,6 @@ export function NavDecks() {
                     )}
                     {dropdownState === DropdownState.import && (
                         <>
-                            <DropdownMenuItem
-                                onClick={(e) => {
-                                    e.preventDefault();
-                                    setDropdownState(DropdownState.initial);
-                                }}
-                                className="gap-2"
-                            >
-                                <ChevronLeft className="h-4 w-4" />
-                                Back
-                            </DropdownMenuItem>
                             <DropdownMenuLabel className="text-muted-foreground">
                                 Import deck
                             </DropdownMenuLabel>
@@ -335,7 +317,7 @@ export function NavDecks() {
                                     disabled
                                 >
                                     Mochi (.mochi)
-                                    <div className="bg-primary text-primary-foreground absolute -top-1 -right-1 rounded-md px-1 py-0.5 text-[0.5rem]">
+                                    <div className="bg-primary text-primary-foreground absolute -top-1 -right-1 rounded-md px-1.5 py-0.5 text-[0.5rem]">
                                         SOON
                                     </div>
                                 </Button>
@@ -345,9 +327,18 @@ export function NavDecks() {
                                     disabled
                                 >
                                     Anki
-                                    <div className="bg-primary text-primary-foreground absolute -top-1 -right-1 rounded-md px-1 py-0.5 text-[0.5rem]">
+                                    <div className="bg-primary text-primary-foreground absolute -top-1 -right-1 rounded-md px-1.5 py-0.5 text-[0.5rem]">
                                         SOON
                                     </div>
+                                </Button>
+                                <Button
+                                    variant="secondary"
+                                    onClick={(e) => {
+                                        e.preventDefault();
+                                        setDropdownState(DropdownState.initial);
+                                    }}
+                                >
+                                    Back
                                 </Button>
                             </div>
                         </>

--- a/web/src/components/nav/nav-decks.tsx
+++ b/web/src/components/nav/nav-decks.tsx
@@ -1,10 +1,27 @@
 import { useQuery, useQueryClient, useMutation } from '@tanstack/react-query';
-import { Plus, RotateCcw, Folder, FolderOpen, ArrowRight } from 'lucide-react';
+import {
+    Plus,
+    RotateCcw,
+    Folder,
+    FolderOpen,
+    ArrowRight,
+    ChevronLeft,
+} from 'lucide-react';
 import Link from 'next/link';
 import { useState } from 'react';
+import { toast } from 'sonner';
 
 import DeckCreationDialog from '@/components/deck-creation-dialog';
 import { TreeView, TreeDataItem } from '@/components/tree-view';
+import { Button } from '@/components/ui/button';
+import {
+    DropdownMenu,
+    DropdownMenuContent,
+    DropdownMenuTrigger,
+    DropdownMenuItem,
+    DropdownMenuLabel,
+} from '@/components/ui/dropdown-menu';
+import { Input } from '@/components/ui/input';
 import {
     SidebarMenu,
     SidebarMenuItem,
@@ -12,6 +29,7 @@ import {
     SidebarGroup,
     SidebarGroupLabel,
     SidebarGroupAction,
+    useSidebar,
 } from '@/components/ui/sidebar';
 import { SidebarMenuSkeleton } from '@/components/ui/sidebar';
 import { DeckNode } from '@/gen';
@@ -28,11 +46,13 @@ export function NavDecks() {
         undefined
     );
     const queryClient = useQueryClient();
+    const { isMobile } = useSidebar();
+
     const {
         data: deckTree,
         isLoading,
         isError,
-        refetch,
+        refetch: refetchDeckTree,
     } = useQuery({
         queryKey: ['decks', 'tree'],
         queryFn: () => getDecksTreeDecksTreeGet(),
@@ -48,7 +68,7 @@ export function NavDecks() {
             queryClient.invalidateQueries({ queryKey: ['decks'] });
         },
         onError: (error) => {
-            // TODO: Add error handling/toast
+            toast.error(`Failed to update deck: ${error}`);
             console.error('Failed to update deck:', error);
         },
     });
@@ -107,7 +127,6 @@ export function NavDecks() {
     return (
         <SidebarGroup>
             <SidebarGroupLabel>Decks</SidebarGroupLabel>
-
             <DeckCreationDialog
                 open={isDialogOpen}
                 onOpenChange={setIsDialogOpen}
@@ -118,19 +137,7 @@ export function NavDecks() {
                 }
                 defaultParentId={defaultParentId}
             />
-
-            <SidebarGroupAction
-                title="Create deck"
-                className="cursor-pointer"
-                hidden={isError}
-                onClick={(_) => {
-                    setDefaultParentId(undefined);
-                    setIsDialogOpen(true);
-                }}
-            >
-                <Plus /> <span className="sr-only">Create deck</span>
-            </SidebarGroupAction>
-
+            <SidebarGroupActionAddDeckDropdown />
             {isLoading && !isError && (
                 <SidebarMenu>
                     <>
@@ -140,13 +147,12 @@ export function NavDecks() {
                     </>
                 </SidebarMenu>
             )}
-
             {isError && !isLoading && (
                 <SidebarMenu>
                     <SidebarMenuItem>
                         <SidebarMenuButton
                             className="text-destructive hover:text-destructive/90 active:text-destructive flex h-fit cursor-pointer justify-between"
-                            onClick={() => refetch()}
+                            onClick={() => refetchDeckTree()}
                             aria-label="Retry loading decks"
                         >
                             <div className="flex flex-col items-start">
@@ -162,7 +168,6 @@ export function NavDecks() {
                     </SidebarMenuItem>
                 </SidebarMenu>
             )}
-
             {deckTree && deckTree.data?.decks.length === 0 && (
                 <SidebarMenu>
                     <SidebarMenuItem>
@@ -175,7 +180,6 @@ export function NavDecks() {
                     </SidebarMenuItem>
                 </SidebarMenu>
             )}
-
             {deckTree && deckTree.data && (
                 <TreeView
                     data={mapToTreeData(deckTree.data.decks)}
@@ -184,4 +188,147 @@ export function NavDecks() {
             )}
         </SidebarGroup>
     );
+
+    function SidebarGroupActionAddDeckDropdown() {
+        enum DropdownState {
+            initial,
+            creation,
+            import,
+        }
+
+        const [dropdownState, setDropdownState] = useState(
+            DropdownState.initial
+        );
+        const [deckName, setDeckName] = useState('');
+        const [deckDescription, setDeckDescription] = useState('');
+
+        return (
+            <DropdownMenu>
+                <DropdownMenuTrigger asChild>
+                    <SidebarGroupAction
+                        title="Add deck"
+                        className="cursor-pointer"
+                        hidden={isError}
+                    >
+                        <Plus /> <span className="sr-only">Create deck</span>
+                    </SidebarGroupAction>
+                </DropdownMenuTrigger>
+                <DropdownMenuContent side={isMobile ? 'bottom' : 'right'}>
+                    {dropdownState === DropdownState.initial && (
+                        <>
+                            <div className="flex flex-col gap-2 p-2">
+                                <Button
+                                    variant="outline"
+                                    onClick={(e) => {
+                                        e.preventDefault();
+                                        setDropdownState(
+                                            DropdownState.creation
+                                        );
+                                    }}
+                                >
+                                    Create deck
+                                </Button>
+                                <Button
+                                    variant="outline"
+                                    onClick={(e) => {
+                                        e.preventDefault();
+                                        setDropdownState(DropdownState.import);
+                                    }}
+                                >
+                                    Import deck
+                                </Button>
+                            </div>
+                        </>
+                    )}
+                    {dropdownState === DropdownState.creation && (
+                        <>
+                            <DropdownMenuLabel className="text-muted-foreground">
+                                Create deck
+                            </DropdownMenuLabel>
+                            <div className="flex flex-col gap-4 p-3">
+                                <div className="flex flex-col gap-2">
+                                    <Input
+                                        id="deck-name"
+                                        type="text"
+                                        placeholder="Deck name"
+                                        value={deckName}
+                                        onChange={(e) =>
+                                            setDeckName(e.target.value)
+                                        }
+                                        className="w-full"
+                                    />
+                                </div>
+                                <div className="flex flex-col gap-2">
+                                    <Input
+                                        id="deck-description"
+                                        type="text"
+                                        placeholder="Description"
+                                        value={deckDescription}
+                                        onChange={(e) =>
+                                            setDeckDescription(e.target.value)
+                                        }
+                                        className="w-full"
+                                    />
+                                </div>
+                                <div className="flex gap-2">
+                                    <Button
+                                        variant="secondary"
+                                        className="flex-1"
+                                        onClick={(e) => {
+                                            e.preventDefault();
+                                            setDropdownState(
+                                                DropdownState.initial
+                                            );
+                                            setDeckName('');
+                                            setDeckDescription('');
+                                        }}
+                                    >
+                                        Cancel
+                                    </Button>
+                                    <Button
+                                        className="flex-1"
+                                        onClick={(e) => {
+                                            e.preventDefault();
+                                            console.log('Create deck:', {
+                                                deckName,
+                                                deckDescription,
+                                            });
+                                        }}
+                                    >
+                                        Create
+                                    </Button>
+                                </div>
+                            </div>
+                        </>
+                    )}
+                    {dropdownState === DropdownState.import && (
+                        <>
+                            <DropdownMenuItem
+                                onClick={(e) => {
+                                    e.preventDefault();
+                                    setDropdownState(DropdownState.initial);
+                                }}
+                                className="gap-2"
+                            >
+                                <ChevronLeft className="h-4 w-4" />
+                                Back
+                            </DropdownMenuItem>
+                            <DropdownMenuLabel className="text-muted-foreground">
+                                Import deck
+                            </DropdownMenuLabel>
+                            <div className="flex flex-col gap-2 p-2">
+                                <Button variant="outline">Repeater</Button>
+                                <Button variant="outline">
+                                    Mochi (markdown)
+                                </Button>
+                                <Button variant="outline" disabled>
+                                    Mochi (soon)
+                                </Button>
+                            </div>
+                        </>
+                    )}
+                </DropdownMenuContent>
+            </DropdownMenu>
+        );
+    }
 }

--- a/web/src/components/nav/nav-decks.tsx
+++ b/web/src/components/nav/nav-decks.tsx
@@ -15,6 +15,11 @@ import {
 } from '@/components/ui/dropdown-menu';
 import { Input } from '@/components/ui/input';
 import {
+    Dropzone,
+    DropzoneContent,
+    DropzoneEmptyState,
+} from '@/components/ui/shadcn-io/dropzone';
+import {
     SidebarMenu,
     SidebarMenuItem,
     SidebarMenuButton,
@@ -183,16 +188,24 @@ export function NavDecks() {
 
     function SidebarGroupActionAddDeckDropdown() {
         enum DropdownState {
-            initial,
-            creation,
-            import,
+            Initial,
+            Creation,
+            Import,
+            ImportUpload,
+        }
+
+        enum ImportFormat {
+            Repeater = 'repeater',
+            MochiMarkdown = 'mochi_markdown',
         }
 
         const [dropdownState, setDropdownState] = useState(
-            DropdownState.initial
+            DropdownState.Initial
         );
+        const [_, setImportFormat] = useState<ImportFormat | null>(null);
         const [deckName, setDeckName] = useState('');
         const [deckDescription, setDeckDescription] = useState('');
+        const [files, setFiles] = useState<File[]>();
 
         return (
             <DropdownMenu>
@@ -206,7 +219,7 @@ export function NavDecks() {
                     </SidebarGroupAction>
                 </DropdownMenuTrigger>
                 <DropdownMenuContent side={isMobile ? 'bottom' : 'right'}>
-                    {dropdownState === DropdownState.initial && (
+                    {dropdownState === DropdownState.Initial && (
                         <>
                             <div className="flex flex-col gap-2 p-2">
                                 <Button
@@ -214,7 +227,7 @@ export function NavDecks() {
                                     onClick={(e) => {
                                         e.preventDefault();
                                         setDropdownState(
-                                            DropdownState.creation
+                                            DropdownState.Creation
                                         );
                                     }}
                                 >
@@ -224,7 +237,7 @@ export function NavDecks() {
                                     variant="outline"
                                     onClick={(e) => {
                                         e.preventDefault();
-                                        setDropdownState(DropdownState.import);
+                                        setDropdownState(DropdownState.Import);
                                     }}
                                 >
                                     Import deck
@@ -232,12 +245,12 @@ export function NavDecks() {
                             </div>
                         </>
                     )}
-                    {dropdownState === DropdownState.creation && (
+                    {dropdownState === DropdownState.Creation && (
                         <>
                             <DropdownMenuLabel className="text-muted-foreground">
                                 Create deck
                             </DropdownMenuLabel>
-                            <div className="flex flex-col gap-4 p-3">
+                            <div className="flex flex-col gap-2 p-2">
                                 <div className="flex flex-col gap-2">
                                     <Input
                                         id="deck-name"
@@ -269,7 +282,7 @@ export function NavDecks() {
                                         onClick={(e) => {
                                             e.preventDefault();
                                             setDropdownState(
-                                                DropdownState.initial
+                                                DropdownState.Initial
                                             );
                                             setDeckName('');
                                             setDeckDescription('');
@@ -293,7 +306,7 @@ export function NavDecks() {
                             </div>
                         </>
                     )}
-                    {dropdownState === DropdownState.import && (
+                    {dropdownState === DropdownState.Import && (
                         <>
                             <DropdownMenuLabel className="text-muted-foreground">
                                 Import deck
@@ -302,12 +315,26 @@ export function NavDecks() {
                                 <Button
                                     variant="outline"
                                     className="flex justify-start"
+                                    onClick={() => {
+                                        setImportFormat(ImportFormat.Repeater);
+                                        setDropdownState(
+                                            DropdownState.ImportUpload
+                                        );
+                                    }}
                                 >
                                     Repeater
                                 </Button>
                                 <Button
                                     variant="outline"
                                     className="flex justify-start"
+                                    onClick={() => {
+                                        setImportFormat(
+                                            ImportFormat.MochiMarkdown
+                                        );
+                                        setDropdownState(
+                                            DropdownState.ImportUpload
+                                        );
+                                    }}
                                 >
                                     Mochi (markdown)
                                 </Button>
@@ -335,11 +362,64 @@ export function NavDecks() {
                                     variant="secondary"
                                     onClick={(e) => {
                                         e.preventDefault();
-                                        setDropdownState(DropdownState.initial);
+                                        setDropdownState(DropdownState.Initial);
                                     }}
                                 >
                                     Back
                                 </Button>
+                            </div>
+                        </>
+                    )}
+                    {dropdownState === DropdownState.ImportUpload && (
+                        <>
+                            <DropdownMenuLabel className="text-muted-foreground">
+                                Import deck / Upload
+                            </DropdownMenuLabel>
+                            <div className="flex flex-col gap-2 p-2">
+                                <Dropzone
+                                    accept={{
+                                        'application/zip': ['.zip'],
+                                        'text/markdown': ['.md'],
+                                    }}
+                                    maxFiles={1}
+                                    maxSize={1024 * 1024 * 50}
+                                    onDrop={(files: File[]) => {
+                                        setFiles(files);
+                                        console.log(files);
+                                    }}
+                                    onError={console.error} // TODO: add proper error handling
+                                    src={files}
+                                >
+                                    <DropzoneEmptyState />
+                                    <DropzoneContent />
+                                </Dropzone>
+
+                                <div className="flex gap-2">
+                                    <Button
+                                        className="flex-1"
+                                        variant="secondary"
+                                        onClick={(e) => {
+                                            e.preventDefault();
+                                            setDropdownState(
+                                                DropdownState.Import
+                                            );
+                                            setFiles([]);
+                                        }}
+                                    >
+                                        Back
+                                    </Button>
+                                    <Button
+                                        className="flex-1"
+                                        onClick={(e) => {
+                                            e.preventDefault();
+                                            console.log(
+                                                'TODO: make import call'
+                                            );
+                                        }}
+                                    >
+                                        Import
+                                    </Button>
+                                </div>
                             </div>
                         </>
                     )}

--- a/web/src/components/ui/shadcn-io/dropzone/index.tsx
+++ b/web/src/components/ui/shadcn-io/dropzone/index.tsx
@@ -1,0 +1,227 @@
+'use client';
+
+import type { ReactNode } from 'react';
+import type { DropEvent, DropzoneOptions, FileRejection } from 'react-dropzone';
+
+import { UploadIcon } from 'lucide-react';
+import { createContext, useContext } from 'react';
+import { useDropzone } from 'react-dropzone';
+
+import { Button } from '@/components/ui/button';
+import { cn } from '@/lib/utils';
+
+type DropzoneContextType = {
+    src?: File[];
+    accept?: DropzoneOptions['accept'];
+    maxSize?: DropzoneOptions['maxSize'];
+    minSize?: DropzoneOptions['minSize'];
+    maxFiles?: DropzoneOptions['maxFiles'];
+};
+
+const renderBytes = (bytes: number) => {
+    const units = ['B', 'KB', 'MB', 'GB', 'TB', 'PB'];
+    let size = bytes;
+    let unitIndex = 0;
+
+    while (size >= 1024 && unitIndex < units.length - 1) {
+        size /= 1024;
+        unitIndex++;
+    }
+
+    return `${size.toFixed(2)}${units[unitIndex]}`;
+};
+
+const DropzoneContext = createContext<DropzoneContextType | undefined>(
+    undefined
+);
+
+export type DropzoneProps = Omit<DropzoneOptions, 'onDrop'> & {
+    src?: File[];
+    className?: string;
+    onDrop?: (
+        acceptedFiles: File[],
+        fileRejections: FileRejection[],
+        event: DropEvent
+    ) => void;
+    children?: ReactNode;
+};
+
+export const Dropzone = ({
+    accept,
+    maxFiles = 1,
+    maxSize,
+    minSize,
+    onDrop,
+    onError,
+    disabled,
+    src,
+    className,
+    children,
+    ...props
+}: DropzoneProps) => {
+    const { getRootProps, getInputProps, isDragActive } = useDropzone({
+        accept,
+        maxFiles,
+        maxSize,
+        minSize,
+        onError,
+        disabled,
+        onDrop: (acceptedFiles, fileRejections, event) => {
+            if (fileRejections.length > 0) {
+                const message = fileRejections.at(0)?.errors.at(0)?.message;
+                onError?.(new Error(message));
+                return;
+            }
+
+            onDrop?.(acceptedFiles, fileRejections, event);
+        },
+        ...props,
+    });
+
+    return (
+        <DropzoneContext.Provider
+            key={JSON.stringify(src)}
+            value={{ src, accept, maxSize, minSize, maxFiles }}
+        >
+            <Button
+                className={cn(
+                    'relative h-auto w-full flex-col overflow-hidden p-8',
+                    isDragActive && 'ring-ring ring-1 outline-none',
+                    className
+                )}
+                disabled={disabled}
+                type="button"
+                variant="outline"
+                {...getRootProps()}
+            >
+                <input {...getInputProps()} disabled={disabled} />
+                {children}
+            </Button>
+        </DropzoneContext.Provider>
+    );
+};
+
+const useDropzoneContext = () => {
+    const context = useContext(DropzoneContext);
+
+    if (!context) {
+        throw new Error('useDropzoneContext must be used within a Dropzone');
+    }
+
+    return context;
+};
+
+export type DropzoneContentProps = {
+    children?: ReactNode;
+    className?: string;
+};
+
+const maxLabelItems = 3;
+
+export const DropzoneContent = ({
+    children,
+    className,
+}: DropzoneContentProps) => {
+    const { src } = useDropzoneContext();
+
+    if (!src) {
+        return null;
+    }
+
+    if (children) {
+        return children;
+    }
+
+    return (
+        <div
+            className={cn(
+                'flex flex-col items-center justify-center',
+                className
+            )}
+        >
+            <div className="bg-muted text-muted-foreground flex size-8 items-center justify-center rounded-md">
+                <UploadIcon size={16} />
+            </div>
+            <p className="my-2 w-full truncate text-sm font-medium">
+                {src.length > maxLabelItems
+                    ? `${new Intl.ListFormat('en').format(
+                          src.slice(0, maxLabelItems).map((file) => file.name)
+                      )} and ${src.length - maxLabelItems} more`
+                    : new Intl.ListFormat('en').format(
+                          src.map((file) => file.name)
+                      )}
+            </p>
+            <p className="text-muted-foreground w-full text-xs text-wrap">
+                Drag and drop or click to replace
+            </p>
+        </div>
+    );
+};
+
+export type DropzoneEmptyStateProps = {
+    children?: ReactNode;
+    className?: string;
+};
+
+export const DropzoneEmptyState = ({
+    children,
+    className,
+}: DropzoneEmptyStateProps) => {
+    const { src, accept, maxSize, minSize, maxFiles } = useDropzoneContext();
+
+    if (src) {
+        return null;
+    }
+
+    if (children) {
+        return children;
+    }
+
+    let caption = '';
+
+    if (accept) {
+        caption += 'Accepts ';
+        const extensions: string[] = [];
+        Object.entries(accept).forEach(([mimeType, exts]) => {
+            if (Array.isArray(exts) && exts.length > 0) {
+                extensions.push(...exts);
+            } else {
+                // Fallback to showing the mime type if no extensions specified
+                extensions.push(mimeType);
+            }
+        });
+        caption += new Intl.ListFormat('en').format(extensions);
+    }
+
+    if (minSize && maxSize) {
+        caption += ` between ${renderBytes(minSize)} and ${renderBytes(maxSize)}`;
+    } else if (minSize) {
+        caption += ` at least ${renderBytes(minSize)}`;
+    } else if (maxSize) {
+        caption += ` less than ${renderBytes(maxSize)}`;
+    }
+
+    return (
+        <div
+            className={cn(
+                'flex flex-col items-center justify-center',
+                className
+            )}
+        >
+            <div className="bg-muted text-muted-foreground flex size-8 items-center justify-center rounded-md">
+                <UploadIcon size={16} />
+            </div>
+            <p className="my-2 w-full truncate text-sm font-medium text-wrap">
+                Upload {maxFiles === 1 ? 'a file' : 'files'}
+            </p>
+            <p className="text-muted-foreground w-full truncate text-xs text-wrap">
+                Drag and drop or click to upload
+            </p>
+            {caption && (
+                <p className="text-muted-foreground text-xs text-wrap">
+                    {caption}.
+                </p>
+            )}
+        </div>
+    );
+};

--- a/web/src/lib/utils.ts
+++ b/web/src/lib/utils.ts
@@ -24,3 +24,16 @@ export function daysSince(date: Date): number {
 
     return diffDays;
 }
+
+export function getErrorMessage(error: unknown): string {
+    if (error instanceof Error) {
+        return error.message;
+    }
+    if (typeof error === 'string') {
+        return error;
+    }
+    if (error && typeof error === 'object' && 'message' in error) {
+        return String(error.message);
+    }
+    return 'An unexpected error occurred';
+}


### PR DESCRIPTION
Includes:
- File upload via picker or drag-and-drop
- Repeater (currently broken) and Mochi markdown formats (.zip or .md)
- Error handling of files
- Loading, success and error state handling for import (simulated 3s delay in demo video)

TODO:
- Fix broken Repeater .json import
- Implement create deck in dropdown modal
- Visual polish including animations


https://github.com/user-attachments/assets/e1ed542b-d659-4175-9e0f-cd6789b9db70

